### PR TITLE
이미지 업로드 관련 API 스펙 작성

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -191,13 +191,12 @@ paths:
                   properties:
                     url:
                       type: string
-                    expiryMillis:
-                      type: integer
-                      format: int64
-                      description: url의 만료까지 남은 밀리초.
+                    expireAt:
+                      $ref: '#/components/schemas/EpochMillisTimestamp'
+                      description: url의 만료 시각.
                   required:
                     - url
-                    - expiryMillis
+                    - expireAt
 
   /registerAccessibility:
     post:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -161,6 +161,44 @@ paths:
                   - placeAccessibilityComments
                   - hasOtherPlacesToRegisterInBuilding
 
+  /getImageUploadUrls:
+    post:
+      summary: 점포 정보 등록 등의 상황에서 이미지를 업로드하기 위한 URL을 받아 온다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                count:
+                  type: integer
+                  description: 업로드할 이미지 수.
+                filenameExtension:
+                  type: string
+                  description: 업로드할 이미지의 확장자. '.'을 붙이지 말아야 한다. e.g. png, jpeg 등.
+              required:
+                - count
+                - filenameExtension
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                    expiryMillis:
+                      type: integer
+                      format: int64
+                      description: url의 만료까지 남은 밀리초.
+                  required:
+                    - url
+                    - expiryMillis
+
   /registerAccessibility:
     post:
       summary: 건물 & 점포의 접근성 정보를 등록한다.
@@ -185,6 +223,10 @@ paths:
                       type: boolean
                     elevatorStairInfo:
                       $ref: '#/components/schemas/StairInfo'
+                    imageUrls:
+                      type: array
+                      items:
+                        type: string
                     comment:
                       type: string
                   required:
@@ -193,6 +235,7 @@ paths:
                     - hasSlope
                     - hasElevator
                     - elevatorStairInfo
+                    - imageUrls
                 placeAccessibilityParams:
                   type: object
                   properties:
@@ -204,6 +247,10 @@ paths:
                       $ref: '#/components/schemas/StairInfo'
                     hasSlope:
                       type: boolean
+                    imageUrls:
+                      type: array
+                      items:
+                        type: string
                     comment:
                       type: string
                   required:
@@ -211,6 +258,7 @@ paths:
                     - isFirstFloor
                     - stairInfo
                     - hasSlope
+                    - imageUrls
               required:
                 - placeAccessibilityParams
       responses:
@@ -529,6 +577,10 @@ components:
           $ref: '#/components/schemas/StairInfo'
         hasSlope:
           type: boolean
+        imageUrls:
+          type: array
+          items:
+            type: string
         placeId:
           type: string
         registeredUserName:
@@ -540,6 +592,7 @@ components:
         - stairInfo
         - hasSlope
         - placeId
+        - imageUrls
 
     PlaceAccessibilityComment:
       description: 점포에 대한 의견.
@@ -574,6 +627,10 @@ components:
           type: boolean
         elevatorStairInfo:
           $ref: '#/components/schemas/StairInfo'
+        imageUrls:
+          type: array
+          items:
+            type: string
         buildingId:
           type: string
         registeredUserName:
@@ -591,6 +648,7 @@ components:
         - hasSlope
         - hasElevator
         - elevatorStairInfo
+        - imageUrls
         - buildingId
         - isUpvoted
         - totalUpvoteCount


### PR DESCRIPTION
- 이미지 업로드를 할 URL을 받아오는 `/getImageUploadUrls` API를 추가합니다. 내려가는 이미지 업로드 url의 expiry는 1분으로 매우 짧으므로, 정보 등록 직전에 받아와서 업로드하시면 됩니다.
  - **이미지를 업로드하실 때는 Content-type, Host, 그리고 x-amz-acl 헤더를 명시해주셔야 합니다. x-amz-acl 헤더의 값은 `public-access`로 해주시면 됩니다.**
- `/registerAccessibility`에서 건물 / 점포 이미지 url 목록을 올릴 수 있도록 수정합니다. `/getImageUploadUrls` 결과로 `https://scc-presigned-url-test.s3.ap-northeast-2.amazonaws.com/b89ba097-9ec5-49b8-8523-7ff4a84eaf10.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20221020T163251Z&X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-acl&X-Amz-Expires=60&X-Amz-Credential=AKIA4D4XV6YRYRBX5PRM%2F20221020%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=1b672aa3236ed6b30da77c0f0da26361d9f19bbff056fee6ed69a23fea03d874%`와 같은 형태의 URL이 내려오는데, `/registerAccessibility` 요청의 request body에는 query params를 다 날리고 올려주시면 됩니다. e.g. `https://scc-presigned-url-test.s3.ap-northeast-2.amazonaws.com/b89ba097-9ec5-49b8-8523-7ff4a84eaf10.txt`
- 건물 정보와 점포 정보에 이미지 url 목록을 내려줍니다.