### PR TITLE
건물 / 장소 정보 등록을 분리해서 하는 시나리오를 위한 API 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -148,30 +148,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  buildingAccessibility:
-                    $ref: '#/components/schemas/BuildingAccessibility'
-                    description: 정보가 아직 채워지지 않았으면 null.
-                  buildingAccessibilityComments:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/BuildingAccessibilityComment'
-                    description: 정보가 아직 채워지지 않았으면 empty list.
-                  placeAccessibility:
-                    $ref: '#/components/schemas/PlaceAccessibility'
-                    description: 정보가 아직 채워지지 않았으면 null.
-                  placeAccessibilityComments:
-                    items:
-                      $ref: '#/components/schemas/PlaceAccessibilityComment'
-                    description: 정보가 아직 채워지지 않았으면 empty list.
-                  hasOtherPlacesToRegisterInBuilding:
-                    type: boolean
-                    description: "'이 건물의 다른 점포 등록하기'를 보여줄지 여부."
-                required:
-                  - buildingAccessibilityComments
-                  - placeAccessibilityComments
-                  - hasOtherPlacesToRegisterInBuilding
+                $ref: '#/components/schemas/AccessibilityInfoDto'
 
   /getImageUploadUrls:
     post:
@@ -221,60 +198,10 @@ paths:
               type: object
               properties:
                 buildingAccessibilityParams:
-                  type: object
+                  $ref: '#/components/schemas/RegisterBuildingAccessibilityRequest'
                   description: 각 건물에 대해 1번만 등록될 수 있다.
-                  properties:
-                    buildingId:
-                      type: string
-                    entranceStairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    entranceImageUrls:
-                      type: array
-                      items:
-                        type: string
-                    hasSlope:
-                      type: boolean
-                    hasElevator:
-                      type: boolean
-                    elevatorStairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    elevatorImageUrls:
-                      type: array
-                      items:
-                        type: string
-                    comment:
-                      type: string
-                  required:
-                    - buildingId
-                    - entranceStairInfo
-                    - entranceImageUrls
-                    - hasSlope
-                    - hasElevator
-                    - elevatorStairInfo
-                    - elevatorImageUrls
                 placeAccessibilityParams:
-                  type: object
-                  properties:
-                    placeId:
-                      type: string
-                    isFirstFloor:
-                      type: boolean
-                    stairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    hasSlope:
-                      type: boolean
-                    imageUrls:
-                      type: array
-                      items:
-                        type: string
-                    comment:
-                      type: string
-                  required:
-                    - placeId
-                    - isFirstFloor
-                    - stairInfo
-                    - hasSlope
-                    - imageUrls
+                  $ref: '#/components/schemas/RegisterPlaceAccessibilityRequest'
               required:
                 - placeAccessibilityParams
       responses:
@@ -752,6 +679,90 @@ components:
         - building
         - hasBuildingAccessibility
         - hasPlaceAccessibility
+
+    AccessibilityInfoDto:
+      type: object
+      properties:
+        buildingAccessibility:
+          $ref: '#/components/schemas/BuildingAccessibility'
+          description: 정보가 아직 채워지지 않았으면 null.
+        buildingAccessibilityComments:
+          type: array
+          items:
+            $ref: '#/components/schemas/BuildingAccessibilityComment'
+          description: 정보가 아직 채워지지 않았으면 empty list.
+        placeAccessibility:
+          $ref: '#/components/schemas/PlaceAccessibility'
+          description: 정보가 아직 채워지지 않았으면 null.
+        placeAccessibilityComments:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceAccessibilityComment'
+          description: 정보가 아직 채워지지 않았으면 empty list.
+        hasOtherPlacesToRegisterInBuilding:
+          type: boolean
+          description: "'이 건물의 다른 점포 등록하기'를 보여줄지 여부."
+      required:
+        - buildingAccessibilityComments
+        - placeAccessibilityComments
+        - hasOtherPlacesToRegisterInBuilding
+
+    RegisterBuildingAccessibilityRequest:
+      type: object
+      description: 각 건물에 대해 1번만 등록될 수 있다.
+      properties:
+        buildingId:
+          type: string
+        entranceStairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        entranceImageUrls:
+          type: array
+          items:
+            type: string
+        hasSlope:
+          type: boolean
+        hasElevator:
+          type: boolean
+        elevatorStairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        elevatorImageUrls:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+      required:
+        - buildingId
+        - entranceStairInfo
+        - entranceImageUrls
+        - hasSlope
+        - hasElevator
+        - elevatorStairInfo
+        - elevatorImageUrls
+
+    RegisterPlaceAccessibilityRequest:
+      type: object
+      properties:
+        placeId:
+          type: string
+        isFirstFloor:
+          type: boolean
+        stairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        hasSlope:
+          type: boolean
+        imageUrls:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+      required:
+        - placeId
+        - isFirstFloor
+        - stairInfo
+        - hasSlope
+        - imageUrls
 
     ApiErrorResponse:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -233,6 +233,56 @@ paths:
                   - placeAccessibility
                   - placeAccessibilityComments
                   - registeredUserOrder
+  
+  /registerPlaceAccessibility:
+    post:
+      summary: 점포의 접근성 정보를 등록한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPlaceAccessibilityRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessibilityInfo:
+                    $ref: '#/components/schemas/AccessibilityInfoDto'
+                  registeredUserOrder:
+                    type: integer
+                    description: "'n번째 정복자'를 표시해주기 위한 값."
+                required:
+                  - accessibilityInfo
+                  - registeredUserOrder
+    
+  /registerBuildingAccessibility:
+    post:
+      summary: 건물 접근성 정보를 등록한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterBuildingAccessibilityRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessibilityInfo:
+                    $ref: '#/components/schemas/AccessibilityInfoDto'
+                  registeredUserOrder:
+                    type: integer
+                    description: "'n번째 정복자'를 표시해주기 위한 값."
+                required:
+                  - accessibilityInfo
+                  - registeredUserOrder
 
   /listPlacesInBuilding:
     post:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -198,10 +198,10 @@ paths:
               type: object
               properties:
                 buildingAccessibilityParams:
-                  $ref: '#/components/schemas/RegisterBuildingAccessibilityRequest'
+                  $ref: '#/components/schemas/RegisterBuildingAccessibilityRequestDto'
                   description: 각 건물에 대해 1번만 등록될 수 있다.
                 placeAccessibilityParams:
-                  $ref: '#/components/schemas/RegisterPlaceAccessibilityRequest'
+                  $ref: '#/components/schemas/RegisterPlaceAccessibilityRequestDto'
               required:
                 - placeAccessibilityParams
       responses:
@@ -242,7 +242,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterPlaceAccessibilityRequest'
+              $ref: '#/components/schemas/RegisterPlaceAccessibilityRequestDto'
       responses:
         '200':
           content:
@@ -267,7 +267,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterBuildingAccessibilityRequest'
+              $ref: '#/components/schemas/RegisterBuildingAccessibilityRequestDto'
       responses:
         '200':
           content:
@@ -757,7 +757,7 @@ components:
         - placeAccessibilityComments
         - hasOtherPlacesToRegisterInBuilding
 
-    RegisterBuildingAccessibilityRequest:
+    RegisterBuildingAccessibilityRequestDto:
       type: object
       description: 각 건물에 대해 1번만 등록될 수 있다.
       properties:
@@ -790,7 +790,7 @@ components:
         - elevatorStairInfo
         - elevatorImageUrls
 
-    RegisterPlaceAccessibilityRequest:
+    RegisterPlaceAccessibilityRequestDto:
       type: object
       properties:
         placeId:


### PR DESCRIPTION
- 기존 `/registerAccessibility` api는 하위 호환을 위해 그대로 두고, `/registerPlaceAccessibility` & `/registerBuildingAccessibility` api를 추가합니다.
- 이 과정에서 재사용되는 object를 component로 뺍니다.