### PR TITLE
카카오 로그인 & 회원가입 플로우 API 구현

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -68,6 +68,27 @@ paths:
             대신 Header의 X-SCC-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
             클라이언트는 이 토큰을 Bearer auth의 토큰으로 사용하면 된다.
 
+  /loginWithKakao:
+    post:
+      summary: 카카오 로그인을 통해 로그인 or 회원가입을 한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                kakaoTokens:
+                  $ref: '#/components/schemas/KakaoTokensDto'
+              required:
+                - kakaoTokens
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResultDto'
+
   /listAdministrativeAreas:
     post:
       summary: 점포를 검색한다.
@@ -451,9 +472,16 @@ paths:
                 instagramId:
                   type: string
                   description: 변경되지 않았으면 기존 값을 그대로 올려준다.
+                email:
+                  type: string
+                mobilityTools:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/UserMobilityToolDto'
               required:
                 - nickname
-                - instagramId
+                - email
+                - mobilityTools
       responses:
         '200':
           content:
@@ -575,6 +603,39 @@ components:
       required:
         - value
 
+    KakaoTokensDto:
+      type: object
+      properties:
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        idToken:
+          type: string
+      required:
+        - accessToken
+        - refreshToken
+        - idToken
+
+    AuthTokensDto:
+      type: object
+      properties:
+        accessToken:
+          type: string
+      required:
+        - accessToken
+
+    LoginResultDto:
+      type: object
+      properties:
+        authTokens:
+          $ref: '#/component/schemas/AuthTokensDto'
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+        - authTokens
+        - user
+
     Location:
       description: 위치를 위경도로 표현하기 위한 모델.
       type: object
@@ -625,9 +686,26 @@ components:
           type: string
         instagramId:
           type: string
+        email:
+          type: string
+        mobilityTools:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserMobilityToolDto'
       required:
         - id
         - nickname
+        - mobilityTools
+
+    UserMobilityToolDto:
+      type: string
+      enum:
+        - MANUAL_WHEELCHAIR # 수동휠체어
+        - ELECTRIC_WHEELCHAIR # 전동휠체어
+        - MANUAL_AND_ELECTRIC_WHEELCHAIR # 수전동휠체어
+        - STROLLER # 유아차 이용자
+        - WALKING_ASSISTANCE_DEVICE # 보행보조기구
+        # TODO: TBD
 
     Place:
       description: 점포 정보.
@@ -711,7 +789,7 @@ components:
         placeId:
           type: string
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
           description: 익명으로 달린 댓글이면 null.
         comment:
           type: string
@@ -722,6 +800,19 @@ components:
         - placeId
         - comment
         - createdAt
+
+    AccessibilityRegistererDto:
+      type: object
+      properties:
+        id:
+          type: string
+        nickname:
+          type: string
+        instagramId:
+          type: string
+      required:
+        - id
+        - nickname
 
     BuildingAccessibility:
       description: 건물의 접근성 정보.
@@ -775,7 +866,7 @@ components:
         buildingId:
           type: string
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
           description: 익명으로 달린 댓글이면 null.
         comment:
           type: string
@@ -934,7 +1025,7 @@ components:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
         conqueredCount:
           type: integer
           description: 접근성 정보를 등록한 장소의 수.


### PR DESCRIPTION
- [기획서](https://www.notion.so/agnica/a8418381554948459dc1e43bbb6d929b)
- 이 PR에서는 두 가지 API만 우선 구현합니다.
  - /loginWithKakao - 카카오 로그인을 통해 로그인 / 회원가입을 합니다. 계정이 이미 존재하면 로그인을 하고, 없으면 회원가입을 합니다.
  - /updateUserInfo - 현재 클라 화면을 보면 기존에 안 쓰던 API인 것 같은데, 여기에 이메일과 이동보조수단을 같이 올릴 수 있게끔 변경해서 회원가입 플로우에서 유저 정보를 입력받을 때 사용할 수 있도록 수정합니다.
- api spec에서 UserDto가 가진 정보가 늘어났는데, api spec 상 accessibility domain 관련 API response에서도 UserDto가 재사용되고 있어서 불필요한 정보가 내려가게 되었습니다. 따라서 이를 막기 위해 accessiblity domain 관련 API response에서는 UserDto 대신 AccessibilityRegistererDto라는 새로운 dto를 내려주도록 수정합니다.