### PR TITLE
Fix: 카카오 로그인 플로우 관련 api spec 수정

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -88,6 +88,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResultDto'
+        '400':
+          $ref: '#/components/responses/ApiFailure'
+          description: |-
+            에러 코드 설명
+            - INVALID_AUTHENTICATION : kakaoTokens 중 일부가 잘못된 경우.
 
   /listAdministrativeAreas:
     post:
@@ -493,6 +498,12 @@ paths:
                     $ref: '#/components/schemas/User'
                 required:
                   - user
+        '400':
+          $ref: '#/components/responses/ApiFailure'
+          description: |-
+            에러 코드 설명
+            - INVALID_NICKNAME : 닉네임이 유효하지 않을 때. e.g. 중복, 2글자 미만 등.
+            - INVALID_EMAIL : 이메일이 유효하지 않을 때. e.g. 중복, 이상한 형태 등.
 
   /deleteUser:
     post:
@@ -629,7 +640,7 @@ components:
       type: object
       properties:
         authTokens:
-          $ref: '#/component/schemas/AuthTokensDto'
+          $ref: '#/components/schemas/AuthTokensDto'
         user:
           $ref: '#/components/schemas/User'
       required:
@@ -1049,9 +1060,13 @@ components:
           x-enum-varnames:
             - INTERNAL_FAILURE # -999999
             - INVALID_AUTHENTICATION # 1
+            - INVALID_NICKNAME # 2
+            - INVALID_EMAIL # 3
           enum:
             - -999999
             - 1
+            - 2
+            - 3
 
     GiveBuildingAccessibilityUpvoteRequestDto:
       type: object


### PR DESCRIPTION
- 개발하다보니 #14 에서 좀 보완해야 하는 부분이 있네요 ㅜㅜ
- 에러에 대한 api response 를 전반적으로 ApiFailure로 바꾸는 걸 같이 가는 게 좋으려나요? 의견 부탁드립니다!