### PR TITLE
애플 로그인 구현

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -335,7 +335,7 @@ paths:
           $ref: '#/components/responses/ApiFailure'
           description: |-
             에러 코드 설명
-            - INVALID_AUTHENTICATION : kakaoTokens 중 일부가 잘못된 경우.
+            - INVALID_AUTHENTICATION : 클라이언트에서 올려준 토큰 중 일부가 잘못된 경우.
 
   /loginWithKakao:
     post:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -316,6 +316,27 @@ paths:
             대신 Header의 X-SCC-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
             클라이언트는 이 토큰을 Bearer auth의 토큰으로 사용하면 된다.
 
+  /loginWithApple:
+    post:
+      summary: 애플 로그인을 통해 로그인 or 회원가입을 한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginWithAppleRequestDto'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResultDto'
+        '400':
+          $ref: '#/components/responses/ApiFailure'
+          description: |-
+            에러 코드 설명
+            - INVALID_AUTHENTICATION : kakaoTokens 중 일부가 잘못된 경우.
+
   /loginWithKakao:
     post:
       summary: 카카오 로그인을 통해 로그인 or 회원가입을 한다.
@@ -864,6 +885,17 @@ components:
       required:
         - authTokens
         - user
+
+    LoginWithAppleRequestDto:
+      type: object
+      properties:
+        identityToken:
+          type: string
+        authorizationCode:
+          type: string
+      required:
+        - identityToken
+        - authorizationCode
 
     Place:
       description: 점포 정보.


### PR DESCRIPTION
- https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#overview <- 이 플로우에 따르면, 애플 로그인은 클라이언트에서 authorization grant code 까지만 취득하고 이후 플로우는 서버에서 처리합니다.
- 클라이언트에서는 [가이드대로 애플 로그인을 진행하신 뒤](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple#3546459)에 [ASAuthorizationAppleIDCredential](https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential) <- 이 객체에 담겨 있는 identityToken / authorizationCode를 올려주시면 됩니다.