### PR TITLE
비회원 유저 생성 API + Security Scheme 명시

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -17,9 +17,15 @@ servers:
           - 'api'
           - 'api.dev'
 
+security:
+  # 모든 API 는 기본적으로 AnonymousUserAuth 를 적용
+  - Anonymous: []
+
 paths:
   /cancelBuildingAccessibilityUpvote:
     post:
+      security:
+        - Identified: []
       requestBody:
         content:
           application/json:
@@ -32,6 +38,8 @@ paths:
 
   /cancelPlaceAccessibilityUpvote:
     post:
+      security:
+        - Identified: []
       requestBody:
         content:
           application/json:
@@ -42,9 +50,22 @@ paths:
         '204': { }
       summary: '''이 정보가 도움이 돼요''를 취소한다.'
 
+  /createAnonymousUser:
+    post:
+      summary: 비회원 계정을 생성한다.
+      security: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAnonymousUserResponseDto'
+
   /createPlaceFavorite:
     post:
       summary: 장소를 즐겨찾기에 추가한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -63,6 +84,8 @@ paths:
       summary: |
         등록한 접근성 정보를 삭제한다.
         기본적으로는 장소 정보만 삭제하지만, 삭제하는 장소 정보가 해당 건물의 마지막 장소 정보일 경우 건물 정보도 함께 삭제한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -83,6 +106,8 @@ paths:
   /deletePlaceFavorite:
     post:
       summary: 장소를 즐겨찾기에서 삭제한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -99,6 +124,8 @@ paths:
   /deleteUser:
     post:
       summary: 계정을 삭제한다.
+      security:
+        - Identified: []
       responses:
         '204': { }
 
@@ -171,6 +198,8 @@ paths:
   /getAccessibilityRank:
     post:
       summary: 내 현재 랭크를 조회한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -192,6 +221,8 @@ paths:
 
   /getCountForNextRank:
     post:
+      security:
+        - Identified: []
       requestBody:
         content:
           application/json:
@@ -215,6 +246,8 @@ paths:
   /getImageUploadUrls:
     post:
       summary: 점포 정보 등록 등의 상황에서 이미지를 업로드하기 위한 URL을 받아 온다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -299,6 +332,8 @@ paths:
   /getAccessibilityActivityReport:
     post:
       summary: 유저 접근성 정보 정복 활동을 조회한다
+      security:
+        - Identified: []
       responses:
         '200':
           content:
@@ -309,6 +344,8 @@ paths:
   /getUserInfo:
     get:
       summary: 유저 정보를 조회한다.
+      security:
+        - Identified: []
       responses:
         '200':
           content:
@@ -319,6 +356,8 @@ paths:
   /giveBuildingAccessibilityUpvote:
     post:
       summary: "'이 정보가 도움이 돼요'를 준다."
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -331,6 +370,8 @@ paths:
   /givePlaceAccessibilityUpvote:
     post:
       summary: "'이 정보가 도움이 돼요'를 준다."
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -343,6 +384,8 @@ paths:
   /joinChallenge:
     post:
       summary: 챌린지에 참여한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -401,6 +444,8 @@ paths:
   /listConqueredPlaces:
     post:
       summary: 내가 정복한 장소 목록을 조회한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -542,6 +587,8 @@ paths:
   /registerBuildingAccessibility:
     post:
       summary: 건물 접근성 정보를 등록한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -557,6 +604,8 @@ paths:
   /registerBuildingAccessibilityComment:
     post:
       summary: 건물에 의견을 추가한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -587,6 +636,8 @@ paths:
   /registerPlaceAccessibility:
     post:
       summary: 점포의 접근성 정보를 등록한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -603,6 +654,8 @@ paths:
   /registerPlaceAccessibilityComment:
     post:
       summary: 점포에 의견을 추가한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -633,6 +686,8 @@ paths:
   /reportAccessibility:
     post:
       summary: 등록된 접근성 정보가 올바르지 않은 경우 신고한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -777,6 +832,8 @@ paths:
   /updateUserInfo:
     post:
       summary: 유저 정보를 수정한다.
+      security:
+        - Identified: []
       requestBody:
         required: true
         content:
@@ -848,6 +905,16 @@ paths:
                 $ref: '#/components/schemas/GetHomeBannersResponseDto'
 
 components:
+  # Security schemes
+  securitySchemes:
+    Anonymous:
+      type: http
+      scheme: bearer
+
+    Identified:
+      type: http
+      scheme: bearer
+
   # Reusable schemas (data models)
   schemas:
     AccessibilityInfoDto:
@@ -1155,6 +1222,14 @@ components:
           type: string
       required:
         - name
+
+    CreateAnonymousUserResponseDto:
+      type: object
+      properties:
+        authTokens:
+          $ref: '#/components/schemas/AuthTokensDto'
+      required:
+        - authTokens
 
     CreatePlaceFavoriteRequestDto:
       type: object


### PR DESCRIPTION
- security scheme 기능을 활용해서 어떤 API 가 어떤 권한을 요구하는지 표기했습니다
- ~다만 하위 호환성 때문에 실제 서버에 이렇게 적용되어 있지는 않은데, 강업이 필요할지 논의를 해봐야 할 것 같아요~
- 어차피 이전 버전에서는 회원가입을 해야 다른 화면이 접근 가능하니까 강업이 필요 없겠군요