### PR TITLE
추천 검색어 내려주기

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2150,13 +2150,10 @@ components:
           type: string
         searchText:
           type: string
-        distanceMetersLimit:
-          type: integer
       required:
         - id
         - description
         - searchText
-        - distanceMetersLimit
 
     SearchPlaceSortDto:
       type: string

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -586,7 +586,7 @@ paths:
   /listSearchPlacePresets:
     post:
       summary: 특정 조건의 검색을 할 수 있는 추천 값을 내려준다.
-      description: ''
+      description: '현재는 추천 키워드만 내려준다'
       requestBody:
         required: true
         content:
@@ -1747,18 +1747,12 @@ components:
     ListSearchPlacePresetsResponseDto:
       type: object
       properties:
-        nearbyPresets:
-          description: '주변 추천 프리셋'
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchPlacePresetDto'
         keywordPresets:
           description: '추천 키워드'
           type: array
           items:
             $ref: '#/components/schemas/SearchPlacePresetDto'
       required:
-        - nearbyPresets
         - keywordPresets
 
     Location:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -583,6 +583,24 @@ paths:
                   - items
                 type: object
 
+  /listSearchPlacePresets:
+    post:
+      summary: 특정 조건의 검색을 할 수 있는 추천 값을 내려준다.
+      description: ''
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSearchPlacePresetsResponseDto'
+
   /login:
     post:
       summary: 로그인을 한다.
@@ -1726,6 +1744,23 @@ components:
         - totalNumberOfItems
         - items
 
+    ListSearchPlacePresetsResponseDto:
+      type: object
+      properties:
+        nearbyPresets:
+          description: '주변 추천 프리셋'
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchPlacePresetDto'
+        keywordPresets:
+          description: '추천 키워드'
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchPlacePresetDto'
+      required:
+        - nearbyPresets
+        - keywordPresets
+
     Location:
       description: 위치를 위경도로 표현하기 위한 모델.
       type: object
@@ -2111,6 +2146,27 @@ components:
       required:
         - category
         - keyword
+
+    SearchPlacePresetDto:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        searchText:
+          type: string
+        distanceMetersLimit:
+          type: integer
+        sort:
+          $ref: '#/components/schemas/SearchPlaceSortDto'
+        filters:
+          $ref: '#/components/schemas/SearchPlaceFilterDto'
+      required:
+        - id
+        - description
+        - searchText
+        - distanceMetersLimit
 
     SearchPlaceSortDto:
       type: string

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -197,6 +197,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccessibilityInfoDto'
 
+  /getNearbyAccessibilityStatus:
+    post:
+      summary: 주변 정복 상태를 조회한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                currentLocation:
+                  $ref: '#/components/schemas/Location'
+                distanceMetersLimit:
+                  type: integer
+      response:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conqueredCount:
+                    type: integer
+
   /getPlaceWithBuilding:
     post:
       summary: 건물 & 점포 정보를 조회한다.

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2152,10 +2152,6 @@ components:
           type: string
         distanceMetersLimit:
           type: integer
-        sort:
-          $ref: '#/components/schemas/SearchPlaceSortDto'
-        filters:
-          $ref: '#/components/schemas/SearchPlaceFilterDto'
       required:
         - id
         - description


### PR DESCRIPTION
- ~nearby(내 주변 여기는 어떠세요?) 와 keyword(추천 키워드) 로 나눠서 내려줍니다~
- ~nearby 의 경우에는 "계단 1칸 이하 음식점" 이 description 이 될 것이고 searchText 는 "음식점" 이 될 것입니다~
- description 을 display 에 사용하면 되고, searchPlaces API 를 호출할 때는 searchText 를 넣어주면 됩니다
  - 근데 추천 검색어에서는 같은게 대부분일 것 같네요 (어떻게 검색하면 어떤 결과가 나오는지를 보여주는게 목적이라서)
- 주변 장소 추천은 주변에 정복된 장소가 있을 때만 보여줄 예정이므로 `getNearbyAccessibilityStatus` api 를 추가해서 주변에 몇개의 장소가 정복되었는지 클라에서 알 수 있도록 합니다

![image](https://github.com/user-attachments/assets/c3cc0ede-bdb6-458d-a134-b6f614f5e35d)
