### PR TITLE
chore: rollback to v3.0

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -1,4 +1,4 @@
-openapi: '3.1.0'
+openapi: '3.0.0'
 info:
   title: Stair Crusher Club Admin API Specification
   version: '1.0.0'
@@ -1172,7 +1172,6 @@ components:
           $ref: '#/components/schemas/AdminChallengeAddressConditionDTO'
         actionCondition:
           $ref: '#/components/schemas/AdminChallengeActionConditionDTO'
-      required: []
 
     AdminChallengeAddressConditionDTO:
       type: object
@@ -1181,7 +1180,6 @@ components:
           type: array
           items:
             type: string
-      required: []
 
     AdminChallengeActionConditionDTO:
       type: object
@@ -1190,7 +1188,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AdminChallengeActionConditionTypeEnumDTO'
-      required: []
 
     AdminChallengeActionConditionTypeEnumDTO:
       type: string
@@ -1689,7 +1686,7 @@ components:
       type: object
       properties:
         scheduledAt:
-          description: '비어 있으면 즉시 전송, 값이 있으면 예약 전송한다'
+          # description: '비어 있으면 즉시 전송, 값이 있으면 예약 전송한다'
           $ref: '#/components/schemas/EpochMillisTimestamp'
         userIds:
           type: array

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1,4 +1,4 @@
-openapi: '3.1.0'
+openapi: '3.0.0'
 info:
   title: Stair Crusher Club API Specification
   version: '1.0.0'
@@ -18,9 +18,6 @@ servers:
 security:
   # 모든 API 는 기본적으로 AnonymousUserAuth 를 적용
   - Anonymous: []
-
-# parameters:
-#   - $ref: '#/components/parameters/SccCommonHeaders'
 
 paths:
   /cancelBuildingAccessibilityUpvote:
@@ -424,7 +421,6 @@ paths:
                     png, jpeg 등.
                 purposeType:
                   $ref: '#/components/schemas/ImageUploadPurpose'
-                  description: 업로드하는 이미지의 타입
               required:
                 - count
                 - filenameExtension
@@ -442,7 +438,6 @@ paths:
                       type: string
                     expireAt:
                       $ref: '#/components/schemas/EpochMillisTimestamp'
-                      description: url의 만료 시각.
                   required:
                     - url
                     - expireAt
@@ -747,9 +742,10 @@ paths:
                 $ref: '#/components/schemas/LoginResultDto'
         '400':
           $ref: '#/components/responses/ApiFailure'
-          description: |-
-            에러 코드 설명
-            - INVALID_AUTHENTICATION : 클라이언트에서 올려준 토큰 중 일부가 잘못된 경우.
+          # open-api v3.1 부터 사용 가능
+          # description: |-
+          #   에러 코드 설명
+          #   - INVALID_AUTHENTICATION : 클라이언트에서 올려준 토큰 중 일부가 잘못된 경우.
 
   /loginWithKakao:
     post:
@@ -775,9 +771,9 @@ paths:
                 $ref: '#/components/schemas/LoginResultDto'
         '400':
           $ref: '#/components/responses/ApiFailure'
-          description: |-
-            에러 코드 설명
-            - INVALID_AUTHENTICATION : kakaoTokens 중 일부가 잘못된 경우.
+          # description: |-
+          #   에러 코드 설명
+          #   - INVALID_AUTHENTICATION : kakaoTokens 중 일부가 잘못된 경우.
 
   /registerBuildingAccessibility:
     post:
@@ -1126,11 +1122,11 @@ paths:
                 type: object
         '400':
           $ref: '#/components/responses/ApiFailure'
-          description: |-
-            에러 코드 설명
-            - INVALID_NICKNAME : 닉네임이 유효하지 않을 때. e.g. 중복, 2글자 미만 등.
-            - INVALID_EMAIL : 이메일이 유효하지 않을 때. e.g. 중복, 이상한 형태 등.
-            - INVALID_BIRTH_YEAR : 출생 연도가 유효하지 않을 때. e.g. 1900년 이전, 2025년 이후 등.
+          # description: |-
+          #   에러 코드 설명
+          #   - INVALID_NICKNAME : 닉네임이 유효하지 않을 때. e.g. 중복, 2글자 미만 등.
+          #   - INVALID_EMAIL : 이메일이 유효하지 않을 때. e.g. 중복, 이상한 형태 등.
+          #   - INVALID_BIRTH_YEAR : 출생 연도가 유효하지 않을 때. e.g. 1900년 이전, 2025년 이후 등.
 
   /updatePushToken:
     post:
@@ -1228,7 +1224,7 @@ components:
       properties:
         buildingAccessibility:
           $ref: '#/components/schemas/BuildingAccessibility'
-          description: 정보가 아직 채워지지 않았으면 null.
+          # description: 정보가 아직 채워지지 않았으면 null.
         buildingAccessibilityComments:
           type: array
           items:
@@ -1236,7 +1232,7 @@ components:
           description: 정보가 아직 채워지지 않았으면 empty list.
         placeAccessibility:
           $ref: '#/components/schemas/PlaceAccessibility'
-          description: 정보가 아직 채워지지 않았으면 null.
+          # description: 정보가 아직 채워지지 않았으면 null.
         placeAccessibilityComments:
           type: array
           items:


### PR DESCRIPTION
- openapi-generator 의 v3.1 지원이 아직 beta 단계이고
- code-gen 과정에 문제가 있어서 일단 3.0 으로 롤백합니다
- https://agnica-coworkingspace.slack.com/archives/C0515M1HMFG/p1752683666549459?thread_ts=1752568997.652399&cid=C0515M1HMFG