### PR TITLE
B2B 챌린지 API spec 구현

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -1208,6 +1208,8 @@ components:
           type: string
         passcode:
           type: string
+        companyName:
+          type: string
         startsAtMillis:
           type: integer
           format: int64

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -1196,6 +1196,7 @@ components:
         - BUILDING_ACCESSIBILITY_COMMENT
         - PLACE_ACCESSIBILITY
         - PLACE_ACCESSIBILITY_COMMENT
+        - PLACE_REVIEW
 
     AdminCreateChallengeRequestDTO:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2723,6 +2723,10 @@ components:
         isCompleted:
           type: boolean
           description: 퀘스트 완료 여부 (참여하지 않은 경우 false)
+        startDate:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+        endDate:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
       required:
         - id
         - title

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1772,7 +1772,6 @@ components:
           description: 참여코드를 입력해야만 참여가 가능한 챌린지에 한해서 필요
         companyInfo:
           $ref: '#/components/schemas/JoinChallengeRequestCompanyJoinInfoDto'
-          description: 회사명과 본인의 이름을 입력해서 참여하는 B2B 챌린지용 정보
       required:
         - challengeId
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1307,7 +1307,7 @@ components:
             - CHALLENGE_NOT_OPENED # 12
             - CHALLENGE_CLOSED # 13
             - INVALID_BIRTH_YEAR # 14
-            - INVALID_COMPANY_NAME # 15
+            - B2B_INFO_REQUIRED # 15
 
           enum:
             - -999999
@@ -1684,9 +1684,9 @@ components:
         hasPasscode:
           type: boolean
           description: 참여코드를 입력해야만 참여할 수 있는 챌린지인지
-        hasCompanyName:
+        isB2B:
           type: boolean
-          description: 회사명을 입력해야만 참여할 수 있는 B2B 챌린지인지
+          description: B2B 챌린지인지 (회사명과 참가자명을 입력받을지 결정)
         quests:
           type: array
           items:
@@ -1697,7 +1697,7 @@ components:
         - ranks
         - hasJoined
         - hasPasscode
-        - hasCompanyName
+        - isB2B
         - quests
 
     GetChallengeWithInvitationCodeRequestDto:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1307,6 +1307,7 @@ components:
             - CHALLENGE_NOT_OPENED # 12
             - CHALLENGE_CLOSED # 13
             - INVALID_BIRTH_YEAR # 14
+            - INVALID_COMPANY_NAME # 15
 
           enum:
             - -999999
@@ -1319,6 +1320,7 @@ components:
             - 12
             - 13
             - 14
+            - 15
 
     AuthTokensDto:
       type: object
@@ -1678,11 +1680,15 @@ components:
         hasPasscode:
           type: boolean
           description: 참여코드를 입력해야만 참여할 수 있는 챌린지인지
+        hasCompanyName:
+          type: boolean
+          description: 회사명을 입력해야만 참여할 수 있는 B2B 챌린지인지
       required:
         - challenge
         - ranks
         - hasJoined
         - hasPasscode
+        - hasCompanyName
 
     GetChallengeWithInvitationCodeRequestDto:
       type: object
@@ -1758,6 +1764,9 @@ components:
         passcode:
           type: string
           description: 참여코드를 입력해야만 참여가 가능한 챌린지에 한해서 필요
+        companyInfo:
+          $ref: '#/components/schemas/JoinChallengeRequestCompanyJoinInfoDto'
+          description: 회사명과 본인의 이름을 입력해서 참여하는 B2B 챌린지용 정보
       required:
         - challengeId
 
@@ -2667,6 +2676,20 @@ components:
         - PLACE_ACCESSIBILITY
         - PLACE_REVIEW
         - TOILET
+
+    JoinChallengeRequestCompanyJoinInfoDto:
+      type: object
+      description: B2B 챌린지 참여 시 회사명과 본인의 이름을 입력받는 DTO. 둘 다 존재하거나 둘 다 null이어야 함.
+      properties:
+        companyName:
+          type: string
+          description: 회사명
+        participantName:
+          type: string
+          description: 본인의 이름
+      required:
+        - companyName
+        - participantName
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1514,6 +1514,10 @@ components:
         nickname:
           type: string
           description: 성과를 이룬 유저 이름.
+        companyName:
+          type: string
+          description: B2B 챌린지의 경우, 회사 이름.
+
       required:
         - rank
         - contributionCount

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1683,12 +1683,18 @@ components:
         hasCompanyName:
           type: boolean
           description: 회사명을 입력해야만 참여할 수 있는 B2B 챌린지인지
+        quests:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChallengeQuestDto'
+          description: 챌린지의 퀘스트 목록 (진행 현황 포함)
       required:
         - challenge
         - ranks
         - hasJoined
         - hasPasscode
         - hasCompanyName
+        - quests
 
     GetChallengeWithInvitationCodeRequestDto:
       type: object
@@ -2690,6 +2696,37 @@ components:
       required:
         - companyName
         - participantName
+
+    ChallengeQuestDto:
+      type: object
+      properties:
+        id:
+          type: string
+          description: 퀘스트 ID
+        title:
+          type: string
+          description: 퀘스트 제목
+        description:
+          type: string
+          description: 퀘스트 설명
+        targetCount:
+          type: integer
+          format: int32
+          description: 목표 완료 개수
+        completedCount:
+          type: integer
+          format: int32
+          description: 현재 완료한 개수 (참여하지 않은 경우 0)
+        isCompleted:
+          type: boolean
+          description: 퀘스트 완료 여부 (참여하지 않은 경우 false)
+      required:
+        - id
+        - title
+        - description
+        - targetCount
+        - completedCount
+        - isCompleted
 
   responses:
     ApiFailure:


### PR DESCRIPTION
- 챌린지 조회 시 퀘스트 정보와 달성률, 달성 완료 여부 등을 같이 내려줍니다.
- 챌린지에 join할 때 기업명과 본인 이름을 입력하고 들어가는 방식을 추가합니다.