### PR TITLE
[리뷰] 두번째 phase api

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1662,10 +1662,8 @@ components:
           type: boolean
           description: B2B 챌린지인지 여부
         b2bFormSchema:
+          # B2B 챌린지 참여 시 보여줄 form에 대한 동적 스키마 (B2B 챌린지인 경우에만 존재)
           $ref: '#/components/schemas/ChallengeB2bFormSchemaDto'
-          description:
-            B2B 챌린지 참여 시 보여줄 form에 대한 동적 스키마 (B2B 챌린지인
-            경우에만 존재)
       required:
         - id
         - name


### PR DESCRIPTION
- 내가 작성한 리뷰 모아보기
  - `/getReviewReport` 는 내부 정보 + 화장실 리뷰를 합쳐서 몇개를 등록했는지 보여줍니다
  - `/listSubmitted(Place|Toilet)Review` 는 각각 paging 이 필요하고, 탭 별로 표기되는 숫자도 각각 카운팅 되기 때문에 endpoint 를 분리했습니다
- 내가 작성한 리뷰 중 도움이 되었어요를 받은 것 모아보기
  - 마찬가지로 place / toilet 따로 엔드포인트가 있습니다
- 도움이 되었어요 자세한 정보 (누른 사람, 사용자 통계)