### PR TITLE
feat: 홈 팝업 API 스펙 추가

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -1203,6 +1203,52 @@ paths:
         '204':
           $ref: '#/components/responses/NoContent'
 
+  /home-popups:
+    get:
+      operationId: adminListHomePopups
+      summary: 홈 팝업 목록을 조회한다.
+      tags:
+        - home-popup
+      responses:
+        '200':
+          description: 팝업 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminListHomePopupsResponseDTO'
+
+    post:
+      operationId: adminCreateHomePopup
+      summary: 홈 팝업을 생성한다.
+      tags:
+        - home-popup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateHomePopupRequestDTO'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+
+  /home-popups/{id}:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+
+    delete:
+      operationId: adminDeleteHomePopup
+      summary: 홈 팝업을 삭제한다.
+      tags:
+        - home-popup
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+
   /home-announcements:
     get:
       operationId: adminListHomeAnnouncements
@@ -3564,6 +3610,51 @@ components:
         - MAIN
         - STRIP
 
+    AdminListHomePopupsResponseDTO:
+      type: object
+      properties:
+        popups:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminHomePopupDTO'
+      required:
+        - popups
+
+    AdminHomePopupDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        imageUrl:
+          type: string
+        displayOrder:
+          type: integer
+          format: int32
+        startAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+        endAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+      required:
+        - id
+        - imageUrl
+        - displayOrder
+
+    AdminCreateHomePopupRequestDTO:
+      type: object
+      properties:
+        imageUrl:
+          type: string
+        displayOrder:
+          type: integer
+          format: int32
+        startAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+        endAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+      required:
+        - imageUrl
+        - displayOrder
+
     AdminListHomeAnnouncementsResponseDTO:
       type: object
       properties:
@@ -3717,6 +3808,7 @@ components:
         - RECOMMENDED_CONTENT
         - PLACE_ACCESSIBILITY_SUGGESTION
         - ACCESSIBILITY
+        - HOME_POPUP
 
     AdminCreateImageUploadUrlsResponseDTO:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -5144,11 +5144,17 @@ components:
           description: 추천 컨텐츠
           items:
             $ref: '#/components/schemas/HomeRecommendedContentDto'
+        homePopups:
+          type: array
+          description: 홈 화면 팝업 (활성 상태, displayOrder 오름차순)
+          items:
+            $ref: '#/components/schemas/HomePopupDto'
       required:
         - mainBanners
         - stripBanners
         - announcements
         - recommendedContents
+        - homePopups
 
     HomeAnnouncementDto:
       type: object
@@ -5166,6 +5172,24 @@ components:
         - id
         - text
         - linkUrl
+
+    HomePopupDto:
+      type: object
+      description: 홈 화면 팝업
+      properties:
+        id:
+          type: string
+        imageUrl:
+          type: string
+          description: 팝업 이미지 URL (제목 텍스트도 이미지에 포함)
+        displayOrder:
+          type: integer
+          format: int32
+          description: 노출 순서 (작을수록 높은 우선순위)
+      required:
+        - id
+        - imageUrl
+        - displayOrder
 
     HomeRecommendedContentDto:
       type: object


### PR DESCRIPTION
## Summary
- `api-spec.yaml`: `HomePopupDto` 추가, `GetHomeScreenDataResponseDto`에 `homePopups` 필드 추가
- `admin-api-spec.yaml`: 홈 팝업 CRUD 엔드포인트 (`/home-popups`) 및 DTO 추가
- `AdminImageUploadPurposeTypeDTO`에 `HOME_POPUP` 추가

## Test plan
- [ ] scc-server `openApiGenerate` 성공
- [ ] scc-admin `pnpm codegen` 성공
- [ ] scc-app `yarn codegen` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)