### PR TITLE
feat: BuildingEntranceCorrectionDto 에 entranceDoorTypes 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4470,7 +4470,7 @@ components:
 
     BuildingEntranceCorrectionDto:
       type: object
-      description: 건물 입구 정보 교정 (계단, 경사로, 사진). 출입문 유형은 DOOR_TYPE 카테고리에서 별도 교정.
+      description: 건물 입구 정보 교정 (계단, 경사로, 문 종류, 사진).
       properties:
         entranceStairInfo:
           $ref: '#/components/schemas/StairInfo'
@@ -4478,6 +4478,10 @@ components:
           $ref: '#/components/schemas/StairHeightLevel'
         hasSlope:
           type: boolean
+        entranceDoorTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntranceDoorType'
         entranceImageUrls:
           type: array
           items:


### PR DESCRIPTION
## 배경

PR #101 이후 신고 교정 플로우에서 **BA(건물 접근성)의 `entranceDoorTypes`를 유저가 교정할 경로가 사라졌다.**

- `DoorType` 카테고리 step 3 는 PA `entranceDoorTypes`만 다루고
- `BuildingEntrance` 카테고리 step 3 는 계단/경사로/사진만 다룸 (`BuildingEntranceCorrectionDto`에 `entranceDoorTypes` 필드 없음)

→ PDP Home 탭 "출입문 유형" (BA `entranceDoorTypes`) 이 틀려도 고칠 수 없는 dead end.

## 변경

`BuildingEntranceCorrectionDto`에 `entranceDoorTypes: Array<EntranceDoorType>` 필드를 추가. description 도 "계단, 경사로, 문 종류, 사진" 으로 갱신.

사용자는 BuildingEntrance 플로우 한 화면에서 건물 입구 관련 모든 틀린 정보(계단/경사로/문 종류/사진)를 한 번에 교정할 수 있게 된다.

## Downstream PRs
- scc-server: (곧 올림)
- scc-app: (곧 올림)

## Test plan
- [x] `npm run format:check` 통과 (관련 부분)
- [ ] downstream 에서 codegen 후 컴파일 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)