### PR TITLE
feat: ClubQuestTargetPlaceDTO 에 floor/floorNum 필드 추가

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -2401,6 +2401,19 @@ components:
         isNotAccessible:
           type: boolean
           description: 장소에 접근 가능한지 여부.
+        floor:
+          type: string
+          description: >-
+            점포가 위치한 층 표시용 문자열 원문. PlaceBusinessInfo.additionalInfo.floor 를 그대로 전달.
+            크롤링 미수집 또는 외부 소스에도 층 정보가 없으면 null.
+          example: "지하1층"
+        floorNum:
+          type: integer
+          description: >-
+            층 정규화 정수. 지상은 양수, 지하는 음수 (예: "B1층" → -1, "3층" → 3).
+            옥상/루프탑 등 정수로 환원 불가한 값 또는 크롤링 미수집 시 null.
+            UI에서는 오름차순 정렬 키로 사용하고, null 은 유효 층 그룹 다음에 배치한다.
+          example: -1
       required:
         - name
         - location


### PR DESCRIPTION
## Summary

- 어드민 퀘스트 조회 응답(`ClubQuestTargetPlaceDTO`)에 장소별 층 정보 두 필드 추가
- `floor`: 표시용 원문 문자열 (`PlaceBusinessInfo.additionalInfo.floor`)
- `floorNum`: 정렬용 정규화 정수 (지상 양수, 지하 음수, 옥상/루프탑 null)

## Why

어드민 퀘스트 페이지에서 정복 대상 장소가 몇 층인지 보이지 않아 현장에서 장소를 찾기 어려운 문제가 있었다. 크롤링된 층 정보를 노출하고, 장소 리스트를 층별로 묶어 보여주기 위한 API 확장이다.

## Downstream

- scc-server: `Converters.kt` 에서 `PlaceBusinessInfo.additionalInfo.{floor,floorNum}` 을 두 필드에 매핑 (별도 PR)
- scc-admin: PlaceCard 에 `(1층)`/`(지하1층)` 인라인 표기 + BuildingDetailSheet `getSortedPlaces` 를 floorNum 오름차순 → 정복 상태 → 이름 3단 정렬로 교체 (별도 PR)
- scc-app: 영향 없음 (api-spec.yaml 만 소비)

## Test plan

- [ ] scc-server 에서 openApiGenerate 성공
- [ ] scc-admin 에서 pnpm codegen 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)