### PR TITLE
feat: ChallengeB2bFormSchema 필드별 isRequired 지원

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -4009,6 +4009,10 @@ components:
             type: string
           nullable: true
           description: 객관식 옵션 (null이면 주관식)
+        isRequired:
+          type: boolean
+          nullable: true
+          description: 필수 입력 여부 (null이면 true로 처리; 기존 필드 backward-compat)
 
     AdminChallengeB2bFormSchemaAvailableFieldNameEnumDTO:
       type: string

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -5057,9 +5057,13 @@ components:
             type: string
           nullable: true
           description: 객관식 옵션 목록 (null이면 주관식)
+        isRequired:
+          type: boolean
+          description: 필수 입력 여부 (true면 빈 값으로 제출 시 검증 실패)
       required:
         - key
         - displayName
+        - isRequired
 
     ChallengeB2bFormAvailableFieldNameTypeDto:
       type: string


### PR DESCRIPTION
## Summary
- `ChallengeB2bFormAvailableFieldDto` (User API) — `isRequired: boolean` 필드 추가 (required로 등록)
- `AdminChallengeB2bFormSchemaAvailableFieldDTO` (Admin API) — `isRequired: boolean` 추가 (nullable, backward-compat)

## Why
운영자가 B2B 챌린지 참가 폼 필드별로 필수/선택을 제어할 수 있도록.
기존 모든 필드는 사실상 required로 강제되어 있었음.

## Backward Compat
- Admin DTO는 `nullable: true`. 기존 admin 클라이언트가 `isRequired`를 누락해도 서버에서 `true`로 처리.

## Downstream PRs
- scc-server: (이 PR 머지 후 별도 PR)
- scc-app / scc-admin: (이 PR 머지 후 별도 PR)

## Test plan
- [ ] downstream codegen 결과에서 `isRequired` 필드가 생성되는지 확인 (서버/앱/어드민 PR에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)