### PR TITLE
feat: 튜토리얼 미션 완료 통합 endpoint + 자동 완료 분리

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1859,8 +1859,8 @@ paths:
         미션별 추가 컨텍스트(예: SAVE_PLACE_LIST 의 placeListId)는 동일 body 에 함께 전달한다.
 
         서버 검증 (미션 타입별):
-        - REGISTER_INTERESTED_REGIONS_AND_THEMES: 사용자가 관심 지역/주제를 1개 이상 등록한 상태인지 확인. 미충족 시 400.
-        - SAVE_PLACE_LIST: context.placeListId 를 사용자가 실제로 저장한 상태인지 확인. 미충족 시 400.
+        - REGISTER_INTERESTED_REGIONS_AND_THEMES: 추가 검증 없음 (클라이언트가 등록 직후 호출).
+        - SAVE_PLACE_LIST: 추가 검증 없음 (클라이언트가 저장 직후 placeListId 와 함께 호출).
         - UPVOTE_ACCESSIBILITY: 추가 검증 없음 (가짜 PDP 에서 사용자 명시 액션 후 호출되므로).
         - HIDDEN_APP_SURVEY: tally API 로 form 제출 기록 검증. 제출 기록 없으면 400.
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1850,17 +1850,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserTutorialProgressDto'
 
-  /completeUserTutorialHiddenMission:
+  /completeUserTutorialMission:
     post:
-      summary: 윌리의 외출 NUX 튜토리얼의 히든 미션 완료를 처리한다.
+      summary: 윌리의 외출 NUX 튜토리얼 미션 완료를 처리한다.
       description: |
-        히든 미션(tally form 제출) 완료 후 호출하여 진행 상태를 업데이트한다.
-        서버는 tally API를 통해 해당 사용자의 form 제출 기록을 검증하며,
-        제출 기록이 없으면 400을 반환한다. 사용자 자가 confirm 방식이 아닌
-        서버 검증 방식으로 동작한다.
+        튜토리얼 전용 화면에서 미션 완료 조건을 충족했을 때 앱이 호출한다.
+        request body 의 missionType 으로 어떤 미션을 완료하려는지 식별하며,
+        미션별 추가 컨텍스트(예: SAVE_PLACE_LIST 의 placeListId)는 동일 body 에 함께 전달한다.
+
+        서버 검증 (미션 타입별):
+        - REGISTER_INTERESTED_REGIONS_AND_THEMES: 사용자가 관심 지역/주제를 1개 이상 등록한 상태인지 확인. 미충족 시 400.
+        - SAVE_PLACE_LIST: context.placeListId 를 사용자가 실제로 저장한 상태인지 확인. 미충족 시 400.
+        - UPVOTE_ACCESSIBILITY: 추가 검증 없음 (가짜 PDP 에서 사용자 명시 액션 후 호출되므로).
+        - HIDDEN_APP_SURVEY: tally API 로 form 제출 기록 검증. 제출 기록 없으면 400.
+
+        idempotent: 이미 완료된 미션이면 no-op + 현재 진행 상태 반환.
+
+        튜토리얼 페이지를 거치지 않은 진입 (홈에서 PublicPlaceList 직접 진입 등) 에서는
+        앱이 이 엔드포인트를 호출하지 않으므로 미션이 완료되지 않는다.
+        실제 데이터 등록/저장 API (savePlaceList, registerUserInterestedRegionsAndThemes,
+        giveAccessibilityUpvote) 는 미션 진행을 자동 기록하지 않는다.
       security:
         - Identified: []
-      operationId: completeUserTutorialHiddenMission
+      operationId: completeUserTutorialMission
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteUserTutorialMissionRequestDto'
       responses:
         '200':
           description: 업데이트된 튜토리얼 미션 진행 상태
@@ -1870,25 +1888,6 @@ paths:
                 $ref: '#/components/schemas/UserTutorialProgressDto'
         '400':
           $ref: '#/components/responses/ApiFailure'
-
-  /completeUserTutorialUpvoteAccessibilityMission:
-    post:
-      summary:
-        윌리의 외출 NUX 튜토리얼 미션 3(접근성 정보 도움돼요)의 완료를 처리한다.
-      description: |
-        튜토리얼 전용 가짜 PDP 화면에서 "도움돼요" 버튼을 눌렀을 때 앱이 호출한다.
-        실제 장소가 아니므로 /giveUpvote 경로 대신 이 엔드포인트로 미션 3(UPVOTE_ACCESSIBILITY)
-        완료를 명시적으로 기록한다. idempotent: 이미 완료된 미션이면 no-op.
-      security:
-        - Identified: []
-      operationId: completeUserTutorialUpvoteAccessibilityMission
-      responses:
-        '200':
-          description: 업데이트된 튜토리얼 미션 진행 상태
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserTutorialProgressDto'
 
   /registerUserInterestedRegionsAndThemes:
     post:
@@ -5733,6 +5732,31 @@ components:
         - SAVE_PLACE_LIST
         - UPVOTE_ACCESSIBILITY
         - HIDDEN_APP_SURVEY
+
+    CompleteUserTutorialMissionRequestDto:
+      type: object
+      description: |
+        튜토리얼 미션 완료 요청. missionType 에 따라 미션별 추가 컨텍스트 필드가 필요할 수도 있다.
+        새 미션 종류가 추가될 때 이 DTO 에 optional context 필드만 추가하면 되도록 설계.
+      properties:
+        missionType:
+          $ref: '#/components/schemas/TutorialMissionTypeDto'
+        savePlaceListContext:
+          description: |
+            missionType 이 SAVE_PLACE_LIST 일 때 필수. 사용자가 저장한 placeList 의 id.
+            서버는 이 id 가 해당 사용자의 UserSavedPlaceList 에 존재하는지 검증한다.
+          $ref: '#/components/schemas/CompleteUserTutorialSavePlaceListMissionContextDto'
+      required:
+        - missionType
+
+    CompleteUserTutorialSavePlaceListMissionContextDto:
+      type: object
+      description: SAVE_PLACE_LIST 미션 완료를 위한 추가 컨텍스트.
+      properties:
+        placeListId:
+          type: string
+      required:
+        - placeListId
 
     RegisterUserInterestedRegionsAndThemesRequestDto:
       type: object


### PR DESCRIPTION
## Summary

- 기존 미션별 endpoint 2개 (`/completeUserTutorialHiddenMission`, `/completeUserTutorialUpvoteAccessibilityMission`) 를 단일 통합 endpoint `/completeUserTutorialMission` 으로 통합. missionType + 미션별 optional context 로 분기.
- 새 미션 종류 추가 시 endpoint 추가 없이 enum + optional context 만 확장하면 된다.
- 부가: 실제 데이터 등록/저장 API 의 자동 미션 완료 트리거는 서버에서 제거 (scc-server PR 에서). 튜토리얼 페이지를 거치지 않고 같은 액션을 해도 미션 완료 X — 앱이 명시적으로 통합 endpoint 호출해야 미션 완료.

## Test plan

- [ ] scc-server PR 머지 후 통합 endpoint 동작 확인
  - REGISTER_INTERESTED_REGIONS_AND_THEMES: 관심 등록 후 호출 → 미션 완료
  - SAVE_PLACE_LIST: placeList 저장 후 placeListId context 와 함께 호출 → 미션 완료
  - UPVOTE_ACCESSIBILITY: 호출 → 미션 완료
  - HIDDEN_APP_SURVEY: tally 제출 후 호출 → 미션 완료
  - context 누락 / 검증 실패 시 400
- [ ] scc-app 에서 통합 hook 으로 호출 흐름 동작 확인