### PR TITLE
fix: AdminAccessibilityReport DTO 의 targetId/targetType nullable 화

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -4677,7 +4677,6 @@ components:
           type: boolean
       required:
         - id
-        - targetType
         - reason
         - createdAt
 
@@ -4727,8 +4726,6 @@ components:
           $ref: '#/components/schemas/AccessibilityReportCorrectionDTO'
       required:
         - id
-        - targetId
-        - targetType
         - reason
         - createdAt
 


### PR DESCRIPTION
## Summary

- 크루의 PA 없는 장소 폐업 신고가 즉시 반영되지 않는 버그를 고치기 위해 `AccessibilityReport` 도메인의 `targetId` / `targetType` 을 nullable 로 바꾸는 작업의 일환.
- 어드민 응답 DTO 의 `targetId` / `targetType` 도 nullable 로 노출해서, 서버가 fallback (`?: ""` / `?: PLACE_ACCESSIBILITY`) 으로 도메인 값을 덮어쓰는 hack 을 제거.

## 변경 사항

- `AdminAccessibilityReportListItemDTO.required` 에서 `targetType` 제거
- `AdminAccessibilityReportDetailDTO.required` 에서 `targetId`, `targetType` 제거

## 다운스트림

- scc-server: 컨트롤러 fallback 제거, 도메인 nullable 그대로 노출
- scc-admin: codegen + 신고 목록/상세에서 null 인 경우 "장소 자체" 라벨링

## Test plan
- [ ] scc-server, scc-admin codegen 후 빌드/타입체크 통과 (각 PR 에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)