### PR TITLE
feat: 웹페이지 저장 지원 API 스펙 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1924,6 +1924,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListInterestedRegionsResponseDto'
 
+  /saveContent:
+    post:
+      summary: 웹페이지 등 컨텐츠를 저장한다.
+      description: |
+        URL을 기준으로 SccContent를 upsert하고, 유저의 UserSavedContent를 생성한다.
+        OG 메타데이터(title, thumbnailUrl, description)는 앱이 웹뷰에서 추출해 전달한다.
+        같은 URL로 이미 저장한 적이 있고 soft delete 상태였다면 다시 살린다.
+      security:
+        - Identified: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveContentRequestDto'
+      responses:
+        '200':
+          description: 저장된 SccContent의 id와 저장 상태를 내려준다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SaveContentResponseDto'
+
+  /unsaveContent:
+    post:
+      summary: 컨텐츠 저장을 해제한다.
+      security:
+        - Identified: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnsaveContentRequestDto'
+      responses:
+        '204':
+          description: 저장 해제 성공.
+
+  /listSavedContents:
+    post:
+      summary: 저장한 컨텐츠 목록을 조회한다.
+      description: |
+        저장 시각 역순(createdAt DESC)으로 페이징한다.
+        '저장한 장소' 페이지의 '저장한 컨텐츠' 탭에서 사용한다.
+      security:
+        - Identified: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListSavedContentsRequestDto'
+      responses:
+        '200':
+          description: 저장한 컨텐츠 목록을 페이징하여 내려준다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSavedContentsResponseDto'
+
+  /getSccContentDetails:
+    post:
+      summary: 웹뷰 컨텐츠의 좋아요 상태, 저장 상태, 메타를 통합 조회한다.
+      description: |
+        웹뷰 진입 시 단일 호출로 isSaved + 좋아요 상태(isUpvoted, totalUpvoteCount) + 컨텐츠 메타를 받아온다.
+        BBUCLE_ROAD 타깃의 좋아요 정보를 별도로 fetch하던 흐름을 이 엔드포인트로 통합한다.
+        sccContentId는 한 번도 저장된 적 없으면 null로 응답한다.
+      security:
+        - Identified: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSccContentDetailsRequestDto'
+      responses:
+        '200':
+          description: 컨텐츠 통합 상세 정보.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSccContentDetailsResponseDto'
+
 components:
   parameters:
     SccCommonHeaders:
@@ -5840,6 +5923,157 @@ components:
       required:
         - id
         - label
+
+    SccContentTypeDto:
+      type: string
+      description: |
+        저장 가능한 컨텐츠 타입. 초기에는 WEB_PAGE 하나만 지원하지만 향후 확장 가능.
+      enum:
+        - WEB_PAGE
+
+    SccContentDto:
+      type: object
+      description: |
+        URL을 기준으로 유일성을 가지는 컨텐츠. title/thumbnail/description은 OG 메타에서 가져온다.
+      properties:
+        id:
+          type: string
+        contentType:
+          $ref: '#/components/schemas/SccContentTypeDto'
+        url:
+          type: string
+        title:
+          type: string
+          description: 컨텐츠 제목. OG title이 없으면 null일 수 있다.
+        thumbnailUrl:
+          type: string
+          description: 컨텐츠 썸네일 URL. OG image가 없으면 null일 수 있다.
+        description:
+          type: string
+          description: 컨텐츠 설명. OG description이 없으면 null일 수 있다.
+      required:
+        - id
+        - contentType
+        - url
+
+    UserSavedContentDto:
+      type: object
+      description: |
+        한 유저가 컨텐츠를 저장한 행위. createdAt은 저장 시각.
+      properties:
+        id:
+          type: string
+        sccContent:
+          $ref: '#/components/schemas/SccContentDto'
+        createdAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+      required:
+        - id
+        - sccContent
+        - createdAt
+
+    SaveContentRequestDto:
+      type: object
+      properties:
+        url:
+          type: string
+          description:
+            저장할 컨텐츠의 URL. 서버에서 정규화 후 unique 키로 사용한다.
+        contentType:
+          $ref: '#/components/schemas/SccContentTypeDto'
+        title:
+          type: string
+          description:
+            앱이 웹뷰의 og:title 또는 document.title에서 추출. 없으면 null.
+        thumbnailUrl:
+          type: string
+          description: 앱이 웹뷰의 og:image에서 추출. 없으면 null.
+        description:
+          type: string
+          description:
+            앱이 웹뷰의 og:description 또는 meta[name=description]에서 추출.
+            없으면 null.
+      required:
+        - url
+        - contentType
+
+    SaveContentResponseDto:
+      type: object
+      properties:
+        sccContentId:
+          type: string
+        isSaved:
+          type: boolean
+          description: 저장 후 상태. 항상 true.
+      required:
+        - sccContentId
+        - isSaved
+
+    UnsaveContentRequestDto:
+      type: object
+      properties:
+        sccContentId:
+          type: string
+      required:
+        - sccContentId
+
+    ListSavedContentsRequestDto:
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description: 페이지 정보. 없으면 첫 페이지 요소들을 내려준다.
+        limit:
+          type: integer
+          format: int64
+
+    ListSavedContentsResponseDto:
+      type: object
+      properties:
+        nextToken:
+          type: string
+          description:
+            다음 페이지 정보. 없으면 더 이상 요청할 값이 없음을 의미한다.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserSavedContentDto'
+      required:
+        - items
+
+    GetSccContentDetailsRequestDto:
+      type: object
+      properties:
+        url:
+          type: string
+          description:
+            조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다.
+      required:
+        - url
+
+    GetSccContentDetailsResponseDto:
+      type: object
+      description: |
+        웹뷰 진입 시 단일 호출용 통합 응답.
+        SccContent가 한 번도 저장된 적 없으면 sccContentId는 null이고 isSaved/isUpvoted는 false다.
+      properties:
+        sccContentId:
+          type: string
+          description: 저장된 적 있다면 SccContent의 id. 없으면 null.
+        isSaved:
+          type: boolean
+          description: 현재 유저가 이 컨텐츠를 저장했는지 여부.
+        isUpvoted:
+          type: boolean
+          description: 현재 유저가 이 컨텐츠에 '도움이 돼요'를 표시했는지 여부.
+        totalUpvoteCount:
+          type: integer
+          format: int64
+          description: 이 컨텐츠가 받은 '도움이 돼요'의 총 개수.
+      required:
+        - isSaved
+        - isUpvoted
+        - totalUpvoteCount
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1931,6 +1931,7 @@ paths:
         URL을 기준으로 SccContent를 upsert하고, 유저의 UserSavedContent를 생성한다.
         OG 메타데이터(title, thumbnailUrl, description)는 앱이 웹뷰에서 추출해 전달한다.
         같은 URL로 이미 저장한 적이 있고 soft delete 상태였다면 다시 살린다.
+      operationId: saveContent
       security:
         - Identified: []
       requestBody:
@@ -1950,6 +1951,7 @@ paths:
   /unsaveContent:
     post:
       summary: 컨텐츠 저장을 해제한다.
+      operationId: unsaveContent
       security:
         - Identified: []
       requestBody:
@@ -1968,6 +1970,7 @@ paths:
       description: |
         저장 시각 역순(createdAt DESC)으로 페이징한다.
         '저장한 장소' 페이지의 '저장한 컨텐츠' 탭에서 사용한다.
+      operationId: listSavedContents
       security:
         - Identified: []
       requestBody:
@@ -1991,6 +1994,8 @@ paths:
         웹뷰 진입 시 단일 호출로 isSaved + 좋아요 상태(isUpvoted, totalUpvoteCount) + 컨텐츠 메타를 받아온다.
         BBUCLE_ROAD 타깃의 좋아요 정보를 별도로 fetch하던 흐름을 이 엔드포인트로 통합한다.
         sccContentId는 한 번도 저장된 적 없으면 null로 응답한다.
+        좋아요 지원 컨텐츠(BBUCLE_ROAD 등)가 아니거나 sccContentId가 없으면 isUpvoted/totalUpvoteCount는 null로 응답한다.
+      operationId: getSccContentDetails
       security:
         - Identified: []
       requestBody:
@@ -6030,6 +6035,10 @@ components:
     ListSavedContentsResponseDto:
       type: object
       properties:
+        totalNumberOfItems:
+          type: integer
+          format: int64
+          description: 저장한 컨텐츠의 전체 개수.
         nextToken:
           type: string
           description:
@@ -6039,6 +6048,7 @@ components:
           items:
             $ref: '#/components/schemas/UserSavedContentDto'
       required:
+        - totalNumberOfItems
         - items
 
     GetSccContentDetailsRequestDto:
@@ -6055,7 +6065,8 @@ components:
       type: object
       description: |
         웹뷰 진입 시 단일 호출용 통합 응답.
-        SccContent가 한 번도 저장된 적 없으면 sccContentId는 null이고 isSaved/isUpvoted는 false다.
+        SccContent가 한 번도 저장된 적 없으면 sccContentId는 null이다.
+        좋아요 지원 컨텐츠가 아니면 isUpvoted/totalUpvoteCount는 null이다.
       properties:
         sccContentId:
           type: string
@@ -6065,15 +6076,17 @@ components:
           description: 현재 유저가 이 컨텐츠를 저장했는지 여부.
         isUpvoted:
           type: boolean
-          description: 현재 유저가 이 컨텐츠에 '도움이 돼요'를 표시했는지 여부.
+          description:
+            현재 유저가 이 컨텐츠에 '도움이 돼요'를 표시했는지 여부. 좋아요 지원
+            컨텐츠(BBUCLE_ROAD 등)가 아니거나 sccContentId가 없으면 null.
         totalUpvoteCount:
           type: integer
           format: int64
-          description: 이 컨텐츠가 받은 '도움이 돼요'의 총 개수.
+          description:
+            이 컨텐츠가 받은 '도움이 돼요'의 총 개수. 좋아요 지원 컨텐츠가
+            아니거나 sccContentId가 없으면 null.
       required:
         - isSaved
-        - isUpvoted
-        - totalUpvoteCount
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1989,11 +1989,12 @@ paths:
 
   /getSccContentDetails:
     post:
-      summary: 웹뷰 컨텐츠의 저장 상태와 메타데이터를 조회한다.
+      summary: 웹뷰 컨텐츠의 저장 상태 + 좋아요 정보를 한 번에 조회한다.
       description: |
-        웹뷰 진입 시 URL 기준으로 SccContent 의 id 와 현재 유저의 저장 여부를 조회한다.
-        한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다.
-        좋아요 정보(isUpvoted/totalUpvoteCount)는 BBUCLE_ROAD 타깃 단위로 별도 유지되므로 이 엔드포인트가 아니라 기존 /getUpvoteDetails 를 사용한다.
+        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 정보를 통합 응답한다.
+        - URL 기준으로 SccContent id + 현재 유저의 저장 여부.
+        - 요청에 upvoteTargetType + upvoteTargetId 를 함께 보내면 응답의 upvoteDetails 에 좋아요 정보가 채워진다.
+        - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다.
       operationId: getSccContentDetails
       security:
         - Identified: []
@@ -5938,7 +5939,9 @@ components:
     SccContentDto:
       type: object
       description: |
-        URL을 기준으로 유일성을 가지는 컨텐츠. title/description/imageUrls는 OG 메타 + 본문 이미지에서 가져온다.
+        URL을 기준으로 유일성을 가지는 컨텐츠.
+        타입별 상세 정보는 별도 detail DTO로 분리되어 nullable 필드로 노출된다.
+        contentType이 WEB_PAGE이면 webPageDetail 이 채워진다. 향후 타입이 늘어나면 각 타입별 detail 필드가 추가된다.
       properties:
         id:
           type: string
@@ -5946,6 +5949,18 @@ components:
           $ref: '#/components/schemas/SccContentTypeDto'
         url:
           type: string
+        webPageDetail:
+          $ref: '#/components/schemas/SccContentWebPageDetailDto'
+      required:
+        - id
+        - contentType
+        - url
+
+    SccContentWebPageDetailDto:
+      type: object
+      description: |
+        WEB_PAGE 타입 SccContent 의 메타데이터. OG 메타 + 본문 이미지에서 추출한다.
+      properties:
         title:
           type: string
           description: 컨텐츠 제목. OG title이 없으면 null일 수 있다.
@@ -5960,9 +5975,6 @@ components:
             컨텐츠 페이지에서 추출한 이미지 URL들. 본문 img + og:image 를 순서대로 수집한다.
             빈 배열일 수 있다. 목록 노출에서는 앞쪽 N장 + 더보기 표기를 사용한다.
       required:
-        - id
-        - contentType
-        - url
         - imageUrls
 
     UserSavedContentDto:
@@ -5983,6 +5995,9 @@ components:
 
     SaveContentRequestDto:
       type: object
+      description: |
+        contentType 에 따라 어떤 detail 필드가 채워져야 하는지가 달라진다.
+        WEB_PAGE 이면 webPageDetail 을 채워서 보낸다. (없거나 비어있어도 받지만 메타가 비어진 채 저장됨)
       properties:
         url:
           type: string
@@ -5990,26 +6005,11 @@ components:
             저장할 컨텐츠의 URL. 서버에서 정규화 후 unique 키로 사용한다.
         contentType:
           $ref: '#/components/schemas/SccContentTypeDto'
-        title:
-          type: string
-          description:
-            앱이 웹뷰의 og:title 또는 document.title에서 추출. 없으면 null.
-        description:
-          type: string
-          description:
-            앱이 웹뷰의 og:description 또는 meta[name=description]에서 추출.
-            없으면 null.
-        imageUrls:
-          type: array
-          items:
-            type: string
-          description: |
-            앱이 웹뷰에서 추출한 이미지 URL들. og:image 와 본문 <img> src 를 합쳐
-            중복 제거 + 등장 순서로 정렬해 보낸다. 비어 있으면 빈 배열을 보낸다.
+        webPageDetail:
+          $ref: '#/components/schemas/SccContentWebPageDetailDto'
       required:
         - url
         - contentType
-        - imageUrls
 
     SaveContentResponseDto:
       type: object
@@ -6025,11 +6025,17 @@ components:
 
     UnsaveContentRequestDto:
       type: object
+      description: |
+        저장 해제 대상을 지정한다. sccContentId 와 url 중 적어도 하나는 필수이며,
+        sccContentId 가 있으면 그 값을 우선 사용하고 없으면 url 로 SccContent 를 찾는다.
+        앱이 SccContent 가 생성되기 전 화면에서도 (URL만 알고 sccContentId 없이) 호출할 수 있도록 url fallback 을 둔다.
       properties:
         sccContentId:
           type: string
-      required:
-        - sccContentId
+          description: 알면 이걸 우선 사용. 모르면 url 로 fallback.
+        url:
+          type: string
+          description: sccContentId 없을 때 사용. 서버에서 정규화 후 SccContent 를 찾는다.
 
     ListSavedContentsRequestDto:
       type: object
@@ -6062,19 +6068,29 @@ components:
 
     GetSccContentDetailsRequestDto:
       type: object
+      description: |
+        웹뷰 진입 시 1회 호출로 저장 상태 + 좋아요 정보까지 모두 받기 위한 통합 요청.
+        upvoteTargetType + upvoteTargetId 를 같이 보내면 응답의 upvoteDetails 가 채워진다.
+        (좋아요 정보가 컨텐츠와 무관하게 별도 키로 관리되어 클라이언트가 target 키를 결정해야 하기 때문이다.)
       properties:
         url:
           type: string
           description:
             조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다.
+        upvoteTargetType:
+          $ref: '#/components/schemas/UpvoteTargetTypeDto'
+        upvoteTargetId:
+          type: string
+          description: 좋아요 대상 ID. upvoteTargetType 과 같이 보낸다.
       required:
         - url
 
     GetSccContentDetailsResponseDto:
       type: object
       description: |
-        URL 기준 SccContent 의 id 와 현재 유저의 저장 여부.
+        URL 기준 SccContent 의 id, 현재 유저의 저장 여부, 그리고 좋아요 정보 (요청에 upvoteTarget* 가 있을 때).
         SccContent 가 한 번도 저장된 적 없으면 sccContentId 는 null 이다.
+        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 좋아요 정보까지 함께 응답한다.
       properties:
         sccContentId:
           type: string
@@ -6082,6 +6098,8 @@ components:
         isSaved:
           type: boolean
           description: 현재 유저가 이 컨텐츠를 저장했는지 여부.
+        upvoteDetails:
+          $ref: '#/components/schemas/GetUpvoteDetailsResponseDto'
       required:
         - isSaved
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1989,11 +1989,12 @@ paths:
 
   /getSccContentDetails:
     post:
-      summary: 웹뷰 컨텐츠의 저장 상태 + 좋아요 정보를 한 번에 조회한다.
+      summary: 웹뷰 컨텐츠의 저장 상태 + 좋아요 요약을 한 번에 조회한다.
       description: |
-        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 정보를 통합 응답한다.
+        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 요약을 통합 응답한다.
         - URL 기준으로 SccContent id + 현재 유저의 저장 여부.
-        - 요청에 upvoteTargetType + upvoteTargetId 를 함께 보내면 응답의 upvoteDetails 에 좋아요 정보가 채워진다.
+        - 서버가 URL pattern 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다.
+        - 좋아요 개념이 적용되지 않는 URL 이면 upvoteSummary 는 null.
         - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다.
       operationId: getSccContentDetails
       security:
@@ -6070,27 +6071,23 @@ components:
       type: object
       description: |
         웹뷰 진입 시 1회 호출로 저장 상태 + 좋아요 정보까지 모두 받기 위한 통합 요청.
-        upvoteTargetType + upvoteTargetId 를 같이 보내면 응답의 upvoteDetails 가 채워진다.
-        (좋아요 정보가 컨텐츠와 무관하게 별도 키로 관리되어 클라이언트가 target 키를 결정해야 하기 때문이다.)
+        클라이언트는 URL 만 보내고, 서버가 URL pattern 으로 좋아요 target 을 추론한다.
       properties:
         url:
           type: string
           description:
             조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다.
-        upvoteTargetType:
-          $ref: '#/components/schemas/UpvoteTargetTypeDto'
-        upvoteTargetId:
-          type: string
-          description: 좋아요 대상 ID. upvoteTargetType 과 같이 보낸다.
+            또한 이 URL 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 도 추론한다.
       required:
         - url
 
     GetSccContentDetailsResponseDto:
       type: object
       description: |
-        URL 기준 SccContent 의 id, 현재 유저의 저장 여부, 그리고 좋아요 정보 (요청에 upvoteTarget* 가 있을 때).
+        URL 기준 SccContent 의 id, 현재 유저의 저장 여부, 그리고 좋아요 요약 정보.
         SccContent 가 한 번도 저장된 적 없으면 sccContentId 는 null 이다.
-        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 좋아요 정보까지 함께 응답한다.
+        웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 좋아요 요약까지 함께 응답한다.
+        URL 이 좋아요 대상이 아니라 좋아요 개념을 적용할 수 없는 컨텐츠면 upvoteSummary 는 null.
       properties:
         sccContentId:
           type: string
@@ -6098,10 +6095,26 @@ components:
         isSaved:
           type: boolean
           description: 현재 유저가 이 컨텐츠를 저장했는지 여부.
-        upvoteDetails:
-          $ref: '#/components/schemas/GetUpvoteDetailsResponseDto'
+        upvoteSummary:
+          $ref: '#/components/schemas/SccContentUpvoteSummaryDto'
       required:
         - isSaved
+
+    SccContentUpvoteSummaryDto:
+      type: object
+      description: |
+        SccContent 의 좋아요 요약. 웹뷰 floating bar 표시에 필요한 최소 정보만 가진다.
+        (PDP 의 GetUpvoteDetailsResponseDto 와는 별도 — 거기엔 누가 눌렀는지 목록이 필요하지만 여기는 불필요.)
+      properties:
+        totalCount:
+          type: integer
+          description: 이 컨텐츠가 받은 총 좋아요 수.
+        isUpvoted:
+          type: boolean
+          description: 현재 유저가 이 컨텐츠에 좋아요를 눌렀는지 여부.
+      required:
+        - totalCount
+        - isUpvoted
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1929,7 +1929,7 @@ paths:
       summary: 웹페이지 등 컨텐츠를 저장한다.
       description: |
         URL을 기준으로 SccContent를 upsert하고, 유저의 UserSavedContent를 생성한다.
-        OG 메타데이터(title, thumbnailUrl, description)는 앱이 웹뷰에서 추출해 전달한다.
+        OG 메타데이터(title, description) + 페이지 본문 이미지(imageUrls)는 앱이 웹뷰에서 추출해 전달한다.
         같은 URL로 이미 저장한 적이 있고 soft delete 상태였다면 다시 살린다.
       operationId: saveContent
       security:
@@ -5938,7 +5938,7 @@ components:
     SccContentDto:
       type: object
       description: |
-        URL을 기준으로 유일성을 가지는 컨텐츠. title/thumbnail/description은 OG 메타에서 가져온다.
+        URL을 기준으로 유일성을 가지는 컨텐츠. title/description/imageUrls는 OG 메타 + 본문 이미지에서 가져온다.
       properties:
         id:
           type: string
@@ -5949,16 +5949,21 @@ components:
         title:
           type: string
           description: 컨텐츠 제목. OG title이 없으면 null일 수 있다.
-        thumbnailUrl:
-          type: string
-          description: 컨텐츠 썸네일 URL. OG image가 없으면 null일 수 있다.
         description:
           type: string
           description: 컨텐츠 설명. OG description이 없으면 null일 수 있다.
+        imageUrls:
+          type: array
+          items:
+            type: string
+          description: |
+            컨텐츠 페이지에서 추출한 이미지 URL들. 본문 img + og:image 를 순서대로 수집한다.
+            빈 배열일 수 있다. 목록 노출에서는 앞쪽 N장 + 더보기 표기를 사용한다.
       required:
         - id
         - contentType
         - url
+        - imageUrls
 
     UserSavedContentDto:
       type: object
@@ -5989,17 +5994,22 @@ components:
           type: string
           description:
             앱이 웹뷰의 og:title 또는 document.title에서 추출. 없으면 null.
-        thumbnailUrl:
-          type: string
-          description: 앱이 웹뷰의 og:image에서 추출. 없으면 null.
         description:
           type: string
           description:
             앱이 웹뷰의 og:description 또는 meta[name=description]에서 추출.
             없으면 null.
+        imageUrls:
+          type: array
+          items:
+            type: string
+          description: |
+            앱이 웹뷰에서 추출한 이미지 URL들. og:image 와 본문 <img> src 를 합쳐
+            중복 제거 + 등장 순서로 정렬해 보낸다. 비어 있으면 빈 배열을 보낸다.
       required:
         - url
         - contentType
+        - imageUrls
 
     SaveContentResponseDto:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6036,7 +6036,8 @@ components:
           description: 알면 이걸 우선 사용. 모르면 url 로 fallback.
         url:
           type: string
-          description: sccContentId 없을 때 사용. 서버에서 정규화 후 SccContent 를 찾는다.
+          description:
+            sccContentId 없을 때 사용. 서버에서 정규화 후 SccContent 를 찾는다.
 
     ListSavedContentsRequestDto:
       type: object
@@ -6076,8 +6077,8 @@ components:
         url:
           type: string
           description:
-            조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다.
-            또한 이 URL 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 도 추론한다.
+            조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다. 또한 이
+            URL 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 도 추론한다.
       required:
         - url
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1989,12 +1989,11 @@ paths:
 
   /getSccContentDetails:
     post:
-      summary: 웹뷰 컨텐츠의 좋아요 상태, 저장 상태, 메타를 통합 조회한다.
+      summary: 웹뷰 컨텐츠의 저장 상태와 메타데이터를 조회한다.
       description: |
-        웹뷰 진입 시 단일 호출로 isSaved + 좋아요 상태(isUpvoted, totalUpvoteCount) + 컨텐츠 메타를 받아온다.
-        BBUCLE_ROAD 타깃의 좋아요 정보를 별도로 fetch하던 흐름을 이 엔드포인트로 통합한다.
-        sccContentId는 한 번도 저장된 적 없으면 null로 응답한다.
-        좋아요 지원 컨텐츠(BBUCLE_ROAD 등)가 아니거나 sccContentId가 없으면 isUpvoted/totalUpvoteCount는 null로 응답한다.
+        웹뷰 진입 시 URL 기준으로 SccContent 의 id 와 현재 유저의 저장 여부를 조회한다.
+        한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다.
+        좋아요 정보(isUpvoted/totalUpvoteCount)는 BBUCLE_ROAD 타깃 단위로 별도 유지되므로 이 엔드포인트가 아니라 기존 /getUpvoteDetails 를 사용한다.
       operationId: getSccContentDetails
       security:
         - Identified: []
@@ -6064,9 +6063,8 @@ components:
     GetSccContentDetailsResponseDto:
       type: object
       description: |
-        웹뷰 진입 시 단일 호출용 통합 응답.
-        SccContent가 한 번도 저장된 적 없으면 sccContentId는 null이다.
-        좋아요 지원 컨텐츠가 아니면 isUpvoted/totalUpvoteCount는 null이다.
+        URL 기준 SccContent 의 id 와 현재 유저의 저장 여부.
+        SccContent 가 한 번도 저장된 적 없으면 sccContentId 는 null 이다.
       properties:
         sccContentId:
           type: string
@@ -6074,17 +6072,6 @@ components:
         isSaved:
           type: boolean
           description: 현재 유저가 이 컨텐츠를 저장했는지 여부.
-        isUpvoted:
-          type: boolean
-          description:
-            현재 유저가 이 컨텐츠에 '도움이 돼요'를 표시했는지 여부. 좋아요 지원
-            컨텐츠(BBUCLE_ROAD 등)가 아니거나 sccContentId가 없으면 null.
-        totalUpvoteCount:
-          type: integer
-          format: int64
-          description:
-            이 컨텐츠가 받은 '도움이 돼요'의 총 개수. 좋아요 지원 컨텐츠가
-            아니거나 sccContentId가 없으면 null.
       required:
         - isSaved
 


### PR DESCRIPTION
## Summary

- 웹뷰 컨텐츠(뿌클로드 등)를 사용자가 "저장"할 수 있게 하는 기능의 API 스펙 추가
- 신규 4개 엔드포인트: `/saveContent`, `/unsaveContent`, `/listSavedContents`, `/getSccContentDetails`
- `SccContent`(URL-unique 컨텐츠 본체) + `UserSavedContent`(유저-컨텐츠 mapping) 두 도메인 모델 도입
- `SccContentTypeDto` enum으로 향후 다른 타입 확장 가능 (초기: `WEB_PAGE`)
- 웹뷰 진입 시 좋아요+저장+메타를 단일 호출로 통합 (`/getSccContentDetails`)

기획: https://www.notion.so/agnica/36ec9499b060803bb3e5c4f1d01d83c8

## Endpoint Summary

| Path | 용도 |
|---|---|
| POST /saveContent | URL+OG 메타 받아 SccContent upsert + UserSavedContent insert |
| POST /unsaveContent | UserSavedContent soft delete (204) |
| POST /listSavedContents | 저장 컨텐츠 cursor 페이징 조회 |
| POST /getSccContentDetails | 좋아요+저장+메타 통합 조회 (웹뷰 진입 시) |

## Test plan

- [ ] 다운스트림 codegen 통과 확인 (server, app — 둘 다 진행)
- [ ] 다음 다운스트림 PR 머지 시점에 함께 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)