### PR TITLE
feat: UserTutorialProgressDto 에 rewardPlaceListId 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -5787,6 +5787,14 @@ components:
             스테이지 0~3 (main 미션 0~3개 완료) + hidden 활성화 상태
             (모든 main 완료 + hidden 미완료 또는 완료). 앱은 하드코딩하지 않고
             서버가 내려주는 URL을 그대로 표시한다.
+        rewardPlaceListId:
+          type: string
+          nullable: true
+          description: |
+            튜토리얼 보상(히든) 저장리스트의 placeListId. 앱은 "히든 저장리스트 보러
+            가기" CTA 에서 이 id 로 해당 place list 상세로 진입한다
+            (deeplink `stair-crusher://place-list/{rewardPlaceListId}`).
+            서버에 보상 리스트가 설정되지 않았거나 익명 사용자처럼 알 수 없는 경우 null.
       required:
         - missions
         - currentMissionType


### PR DESCRIPTION
튜토리얼 보상(히든) 저장리스트 placeListId 를 progress 응답에 노출.

앱이 "히든 저장리스트 보러 가기" CTA 에서 deeplink `stair-crusher://place-list/{rewardPlaceListId}` 로 진입하기 위함. 보상 리스트 미설정/익명 사용자면 null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)