### PR TITLE
feat: ToiletAccessibility 통합 OpenAPI 스펙 추가

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -5247,7 +5247,8 @@ components:
       properties:
         id:
           type: string
-          description: '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
+          description:
+            '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
         images:
           type: array
           items:
@@ -5255,7 +5256,8 @@ components:
         toiletLocationType:
           type: string
           nullable: true
-          description: '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
+          description:
+            '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
         locationComment:
           type: string
           nullable: true
@@ -5335,7 +5337,8 @@ components:
         toiletAccessibilities:
           type: array
           description:
-            '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터). 큐레이션 판단용. 없으면 빈 배열'
+            '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터). 큐레이션
+            판단용. 없으면 빈 배열'
           items:
             $ref: '#/components/schemas/AdminToiletAccessibilityDto'
 

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -2205,37 +2205,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/AdminExperimentAssignmentDto'
 
-  /toilet-accessibilities/search:
+  /toilets/search:
     post:
       tags:
-        - admin-toilet-accessibility
-      summary: 통합 화장실 접근성 목록을 조회한다. (큐레이션 큐 조회용)
+        - admin-toilet
+      summary: 화장실 목록을 조회한다. (큐레이션 큐 조회용)
       description: |
-        sourceType, isSearchable 필터로 ToiletAccessibility 목록을 페이지네이션 조회한다.
-        USER + isSearchable=false 목록을 내려 운영자가 사진/comment/위치유형을 보고 검색 대상 여부를 판단한다.
-      operationId: adminSearchToiletAccessibilities
+        isSearchable 필터로 Toilet 목록을 페이지네이션 조회한다.
+        isSearchable=false 목록을 내려 운영자가 병합된 유저 리뷰의 사진/comment/위치유형을 보고 검색 대상 여부를 판단한다.
+      operationId: adminSearchToilets
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AdminSearchToiletAccessibilitiesRequestDto'
+              $ref: '#/components/schemas/AdminSearchToiletsRequestDto'
       responses:
         '200':
-          description: 통합 화장실 목록
+          description: 화장실 목록
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminSearchToiletAccessibilitiesResponseDto'
+                $ref: '#/components/schemas/AdminSearchToiletsResponseDto'
 
-  /toilet-accessibilities/{id}/set-searchable:
+  /toilets/{id}/set-searchable:
     post:
       tags:
-        - admin-toilet-accessibility
-      summary: 화장실 접근성 검색 대상 여부를 설정한다.
+        - admin-toilet
+      summary: 화장실 검색 대상 여부를 설정한다.
       description: |
         isSearchable=true 로 설정하면 즉시 검색에 노출되고, false 로 설정하면 즉시 제외된다.
-      operationId: setToiletAccessibilitySearchable
+      operationId: setToiletSearchable
       parameters:
         - name: id
           in: path
@@ -2247,7 +2247,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetToiletAccessibilitySearchableRequestDto'
+              $ref: '#/components/schemas/SetToiletSearchableRequestDto'
       responses:
         '200':
           description: 성공
@@ -5236,16 +5236,9 @@ components:
         bbucleRoadData:
           $ref: '#/components/schemas/AdminPlaceSpecialAccessibilityBbucleRoadDataDto'
 
-    ToiletAccessibilitySourceTypeDto:
-      type: string
-      description: '화장실 접근성 데이터 소스 타입'
-      enum:
-        - USER_TOILET_REVIEW
-        - EXTERNAL_ACCESSIBILITY
-
     AdminToiletReviewDetailDto:
       type: object
-      description: 'USER_TOILET_REVIEW 소스의 원본 ToiletReview 상세 정보'
+      description: 'Toilet에 병합된 유저 리뷰(ToiletReview)의 상세 정보'
       properties:
         toiletLocationType:
           type: string
@@ -5263,20 +5256,18 @@ components:
           items:
             $ref: '#/components/schemas/AdminImageDTO'
 
-    AdminToiletAccessibilityDto:
+    AdminToiletDto:
       type: object
       required:
         - id
-        - sourceType
         - name
         - isSearchable
-        - hasImage
+        - hasExternalSource
         - createdAt
+        - toiletReviewDetails
       properties:
         id:
           type: string
-        sourceType:
-          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
         name:
           type: string
         address:
@@ -5285,25 +5276,21 @@ components:
         isSearchable:
           type: boolean
           description: '검색 노출 여부'
-        hasImage:
+        hasExternalSource:
           type: boolean
-          description: '이미지 보유 여부'
-        thumbnailUrl:
-          type: string
-          nullable: true
+          description: '공공데이터(ExternalAccessibility) 소스 병합 여부'
         createdAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
-        toiletReviewDetail:
-          $ref: '#/components/schemas/AdminToiletReviewDetailDto'
-          nullable: true
-          description: 'USER_TOILET_REVIEW 소스일 때만 포함'
+        toiletReviewDetails:
+          type: array
+          description:
+            '이 Toilet에 병합된 유저 리뷰들 (큐레이션 판단용). 없으면 빈 배열'
+          items:
+            $ref: '#/components/schemas/AdminToiletReviewDetailDto'
 
-    AdminSearchToiletAccessibilitiesRequestDto:
+    AdminSearchToiletsRequestDto:
       type: object
       properties:
-        sourceType:
-          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
-          nullable: true
         isSearchable:
           type: boolean
           nullable: true
@@ -5315,7 +5302,7 @@ components:
           type: integer
           default: 20
 
-    AdminSearchToiletAccessibilitiesResponseDto:
+    AdminSearchToiletsResponseDto:
       type: object
       required:
         - items
@@ -5323,12 +5310,12 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/AdminToiletAccessibilityDto'
+            $ref: '#/components/schemas/AdminToiletDto'
         nextPageToken:
           type: string
           nullable: true
 
-    SetToiletAccessibilitySearchableRequestDto:
+    SetToiletSearchableRequestDto:
       type: object
       required:
         - isSearchable

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -5238,26 +5238,26 @@ components:
 
     ToiletAccessibilitySourceTypeDto:
       type: string
-      description: "화장실 접근성 데이터 소스 타입"
+      description: '화장실 접근성 데이터 소스 타입'
       enum:
         - USER_TOILET_REVIEW
         - EXTERNAL_ACCESSIBILITY
 
     AdminToiletReviewDetailDto:
       type: object
-      description: "USER_TOILET_REVIEW 소스의 원본 ToiletReview 상세 정보"
+      description: 'USER_TOILET_REVIEW 소스의 원본 ToiletReview 상세 정보'
       properties:
         toiletLocationType:
           type: string
-          description: "화장실 위치 유형 (PLACE / BUILDING / NONE / ETC)"
+          description: '화장실 위치 유형 (PLACE / BUILDING / NONE / ETC)'
         locationComment:
           type: string
           nullable: true
-          description: "화장실 위치 설명"
+          description: '화장실 위치 설명'
         comment:
           type: string
           nullable: true
-          description: "기타 참고사항"
+          description: '기타 참고사항'
         images:
           type: array
           items:
@@ -5284,10 +5284,10 @@ components:
           nullable: true
         isSearchable:
           type: boolean
-          description: "검색 노출 여부"
+          description: '검색 노출 여부'
         hasImage:
           type: boolean
-          description: "이미지 보유 여부"
+          description: '이미지 보유 여부'
         thumbnailUrl:
           type: string
           nullable: true
@@ -5296,7 +5296,7 @@ components:
         toiletReviewDetail:
           $ref: '#/components/schemas/AdminToiletReviewDetailDto'
           nullable: true
-          description: "USER_TOILET_REVIEW 소스일 때만 포함"
+          description: 'USER_TOILET_REVIEW 소스일 때만 포함'
 
     AdminSearchToiletAccessibilitiesRequestDto:
       type: object
@@ -5307,7 +5307,7 @@ components:
         isSearchable:
           type: boolean
           nullable: true
-          description: "검색 노출 여부 필터. null이면 전체 조회"
+          description: '검색 노출 여부 필터. null이면 전체 조회'
         nextPageToken:
           type: string
           nullable: true
@@ -5335,7 +5335,9 @@ components:
       properties:
         isSearchable:
           type: boolean
-          description: "검색 노출 여부. true로 설정하면 즉시 검색에 노출, false로 설정하면 즉시 제외"
+          description:
+            '검색 노출 여부. true로 설정하면 즉시 검색에 노출, false로 설정하면
+            즉시 제외'
 
   responses:
     NoContent:

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -2205,6 +2205,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/AdminExperimentAssignmentDto'
 
+  /toilet-accessibilities/search:
+    post:
+      tags:
+        - admin-toilet-accessibility
+      summary: 통합 화장실 접근성 목록을 조회한다. (큐레이션 큐 조회용)
+      description: |
+        sourceType, isSearchable 필터로 ToiletAccessibility 목록을 페이지네이션 조회한다.
+        USER + isSearchable=false 목록을 내려 운영자가 사진/comment/위치유형을 보고 검색 대상 여부를 판단한다.
+      operationId: adminSearchToiletAccessibilities
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminSearchToiletAccessibilitiesRequestDto'
+      responses:
+        '200':
+          description: 통합 화장실 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminSearchToiletAccessibilitiesResponseDto'
+
+  /toilet-accessibilities/{id}/set-searchable:
+    post:
+      tags:
+        - admin-toilet-accessibility
+      summary: 화장실 접근성 검색 대상 여부를 설정한다.
+      description: |
+        isSearchable=true 로 설정하면 즉시 검색에 노출되고, false 로 설정하면 즉시 제외된다.
+      operationId: setToiletAccessibilitySearchable
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetToiletAccessibilitySearchableRequestDto'
+      responses:
+        '200':
+          description: 성공
+          $ref: '#/components/responses/NoContent'
+
 components:
   # Reusable schemas (data models)
   securitySchemes:
@@ -5187,6 +5235,107 @@ components:
       properties:
         bbucleRoadData:
           $ref: '#/components/schemas/AdminPlaceSpecialAccessibilityBbucleRoadDataDto'
+
+    ToiletAccessibilitySourceTypeDto:
+      type: string
+      description: "화장실 접근성 데이터 소스 타입"
+      enum:
+        - USER_TOILET_REVIEW
+        - EXTERNAL_ACCESSIBILITY
+
+    AdminToiletReviewDetailDto:
+      type: object
+      description: "USER_TOILET_REVIEW 소스의 원본 ToiletReview 상세 정보"
+      properties:
+        toiletLocationType:
+          type: string
+          description: "화장실 위치 유형 (PLACE / BUILDING / NONE / ETC)"
+        locationComment:
+          type: string
+          nullable: true
+          description: "화장실 위치 설명"
+        comment:
+          type: string
+          nullable: true
+          description: "기타 참고사항"
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminImageDTO'
+
+    AdminToiletAccessibilityDto:
+      type: object
+      required:
+        - id
+        - sourceType
+        - name
+        - isSearchable
+        - hasImage
+        - createdAt
+      properties:
+        id:
+          type: string
+        sourceType:
+          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
+        name:
+          type: string
+        address:
+          type: string
+          nullable: true
+        isSearchable:
+          type: boolean
+          description: "검색 노출 여부"
+        hasImage:
+          type: boolean
+          description: "이미지 보유 여부"
+        thumbnailUrl:
+          type: string
+          nullable: true
+        createdAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+        toiletReviewDetail:
+          $ref: '#/components/schemas/AdminToiletReviewDetailDto'
+          nullable: true
+          description: "USER_TOILET_REVIEW 소스일 때만 포함"
+
+    AdminSearchToiletAccessibilitiesRequestDto:
+      type: object
+      properties:
+        sourceType:
+          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
+          nullable: true
+        isSearchable:
+          type: boolean
+          nullable: true
+          description: "검색 노출 여부 필터. null이면 전체 조회"
+        nextPageToken:
+          type: string
+          nullable: true
+        limit:
+          type: integer
+          default: 20
+
+    AdminSearchToiletAccessibilitiesResponseDto:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminToiletAccessibilityDto'
+        nextPageToken:
+          type: string
+          nullable: true
+
+    SetToiletAccessibilitySearchableRequestDto:
+      type: object
+      required:
+        - isSearchable
+      properties:
+        isSearchable:
+          type: boolean
+          description: "검색 노출 여부. true로 설정하면 즉시 검색에 노출, false로 설정하면 즉시 제외"
 
   responses:
     NoContent:

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -5236,25 +5236,76 @@ components:
         bbucleRoadData:
           $ref: '#/components/schemas/AdminPlaceSpecialAccessibilityBbucleRoadDataDto'
 
-    AdminToiletReviewDetailDto:
+    AdminToiletAccessibilityDto:
       type: object
-      description: 'Toilet에 병합된 유저 리뷰(ToiletReview)의 상세 정보'
+      description: |
+        Toilet에 병합된 단일 소스(유저 리뷰 ToiletReview 또는 공공데이터 ExternalAccessibility)의
+        접근성 정보. 소스 종류에 따라 채워지는 필드가 다르며, 어드민은 존재하는 필드로 큐레이션을 판단한다.
+      required:
+        - id
+        - images
       properties:
-        toiletLocationType:
+        id:
           type: string
-          description: '화장실 위치 유형 (PLACE / BUILDING / NONE / ETC)'
-        locationComment:
-          type: string
-          nullable: true
-          description: '화장실 위치 설명'
-        comment:
-          type: string
-          nullable: true
-          description: '기타 참고사항'
+          description: '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
         images:
           type: array
           items:
             $ref: '#/components/schemas/AdminImageDTO'
+        toiletLocationType:
+          type: string
+          nullable: true
+          description: '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
+        locationComment:
+          type: string
+          nullable: true
+          description: '화장실 위치 설명 (유저 리뷰 소스)'
+        comment:
+          type: string
+          nullable: true
+          description: '기타 참고사항 (유저 리뷰 소스)'
+        toiletDetails:
+          $ref: '#/components/schemas/AdminToiletAccessibilityDetailsDto'
+          nullable: true
+          description: '공공데이터 소스 상세 필드'
+
+    AdminToiletAccessibilityDetailsDto:
+      type: object
+      description: '공공데이터(ExternalAccessibility) 화장실 상세 필드'
+      properties:
+        gender:
+          type: string
+          nullable: true
+        accessDesc:
+          type: string
+          nullable: true
+        availableDesc:
+          type: string
+          nullable: true
+        entranceDesc:
+          type: string
+          nullable: true
+        stallWidth:
+          type: string
+          nullable: true
+        stallDepth:
+          type: string
+          nullable: true
+        doorDesc:
+          type: string
+          nullable: true
+        doorSideRoom:
+          type: string
+          nullable: true
+        washStandBelowRoom:
+          type: string
+          nullable: true
+        washStandHandle:
+          type: string
+          nullable: true
+        extraDesc:
+          type: string
+          nullable: true
 
     AdminToiletDto:
       type: object
@@ -5264,7 +5315,7 @@ components:
         - isSearchable
         - hasExternalSource
         - createdAt
-        - toiletReviewDetails
+        - toiletAccessibilities
       properties:
         id:
           type: string
@@ -5281,12 +5332,12 @@ components:
           description: '공공데이터(ExternalAccessibility) 소스 병합 여부'
         createdAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
-        toiletReviewDetails:
+        toiletAccessibilities:
           type: array
           description:
-            '이 Toilet에 병합된 유저 리뷰들 (큐레이션 판단용). 없으면 빈 배열'
+            '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터). 큐레이션 판단용. 없으면 빈 배열'
           items:
-            $ref: '#/components/schemas/AdminToiletReviewDetailDto'
+            $ref: '#/components/schemas/AdminToiletAccessibilityDto'
 
     AdminSearchToiletsRequestDto:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4245,7 +4245,7 @@ components:
         locationComment:
           type: string
           nullable: true
-          description: "화장실 위치 설명 (기타 참고사항과 별도)"
+          description: '화장실 위치 설명 (기타 참고사항과 별도)'
         comment:
           type: string
           description: 화장실에 대해 자세히 알려주세요
@@ -5026,7 +5026,7 @@ components:
         locationComment:
           type: string
           nullable: true
-          description: "화장실 위치 설명 (기타 참고사항과 별도)"
+          description: '화장실 위치 설명 (기타 참고사항과 별도)'
         comment:
           type: string
         images:
@@ -6242,7 +6242,7 @@ components:
 
     ToiletAccessibilitySourceTypeDto:
       type: string
-      description: "화장실 접근성 데이터 소스 타입"
+      description: '화장실 접근성 데이터 소스 타입'
       enum:
         - USER_TOILET_REVIEW
         - EXTERNAL_ACCESSIBILITY
@@ -6257,11 +6257,11 @@ components:
         limit:
           type: integer
           default: 50
-          description: "nearest-N 개수 (기본 50)"
+          description: 'nearest-N 개수 (기본 50)'
         distanceMetersLimit:
           type: integer
           nullable: true
-          description: "최대 반경 (미터). 없으면 limit만 적용"
+          description: '최대 반경 (미터). 없으면 limit만 적용'
 
     SearchToiletAccessibilitiesResponseDto:
       type: object
@@ -6283,7 +6283,7 @@ components:
       properties:
         id:
           type: string
-          description: "ToiletAccessibility ID (prefix: TA)"
+          description: 'ToiletAccessibility ID (prefix: TA)'
         sourceType:
           $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
         name:
@@ -6332,19 +6332,19 @@ components:
         locationComment:
           type: string
           nullable: true
-          description: "화장실 위치 설명 (USER 소스)"
+          description: '화장실 위치 설명 (USER 소스)'
         comment:
           type: string
           nullable: true
-          description: "기타 참고사항 (USER 소스)"
+          description: '기타 참고사항 (USER 소스)'
         toiletDetails:
           $ref: '#/components/schemas/ToiletAccessibilityDetails'
           nullable: true
-          description: "EXTERNAL 소스 상세 필드"
+          description: 'EXTERNAL 소스 상세 필드'
         referenceTargetId:
           type: string
           nullable: true
-          description: "USER 소스의 placeId/buildingId (앱에서 PDP 이동 보조)"
+          description: 'USER 소스의 placeId/buildingId (앱에서 PDP 이동 보조)'
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2030,48 +2030,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetSccContentDetailsResponseDto'
 
-  /searchToiletAccessibilities:
+  /searchToilets:
     post:
       tags:
-        - toilet-accessibility
-      summary: 통합 화장실 접근성 정보를 위치 기반으로 검색한다.
+        - toilet
+      summary: 화장실을 위치 기반으로 검색한다.
       description: |
-        isSearchable=true 인 ToiletAccessibility를 위치 기반 nearest-N으로 반환한다.
-        공공데이터(ExternalAccessibility)와 유저 등록(ToiletReview) 두 소스를 통합하여 제공한다.
-      operationId: searchToiletAccessibilities
+        isSearchable=true 인 Toilet을 위치 기반 nearest-N으로 반환한다.
+        하나의 Toilet은 공공데이터(ExternalAccessibility)와 유저 등록(ToiletReview) 소스가 병합된 통합 화장실이다.
+      operationId: searchToilets
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SearchToiletAccessibilitiesRequestDto'
+              $ref: '#/components/schemas/SearchToiletsRequestDto'
       responses:
         '200':
-          description: 통합 화장실 검색 결과 (isSearchable=true만, nearest-N)
+          description: 화장실 검색 결과 (isSearchable=true만, nearest-N)
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SearchToiletAccessibilitiesResponseDto'
+                $ref: '#/components/schemas/SearchToiletsResponseDto'
 
-  /getToiletAccessibility:
+  /getToilet:
     post:
       tags:
-        - toilet-accessibility
-      summary: 통합 화장실 접근성 상세 정보를 조회한다.
-      operationId: getToiletAccessibility
+        - toilet
+      summary: 화장실 상세 정보를 조회한다.
+      description: |
+        Toilet과 그에 병합된 모든 소스(ToiletReview/ExternalAccessibility)를 조합해 상세 정보를 내려준다.
+      operationId: getToilet
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GetToiletAccessibilityRequestDto'
+              $ref: '#/components/schemas/GetToiletRequestDto'
       responses:
         '200':
-          description: 통합 화장실 상세 정보
+          description: 화장실 상세 정보
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ToiletAccessibilityDetailDto'
+                $ref: '#/components/schemas/ToiletDetailDto'
 
 components:
   parameters:
@@ -6240,14 +6242,7 @@ components:
         - totalCount
         - isUpvoted
 
-    ToiletAccessibilitySourceTypeDto:
-      type: string
-      description: '화장실 접근성 데이터 소스 타입'
-      enum:
-        - USER_TOILET_REVIEW
-        - EXTERNAL_ACCESSIBILITY
-
-    SearchToiletAccessibilitiesRequestDto:
+    SearchToiletsRequestDto:
       type: object
       required:
         - currentLocation
@@ -6263,7 +6258,7 @@ components:
           nullable: true
           description: '최대 반경 (미터). 없으면 limit만 적용'
 
-    SearchToiletAccessibilitiesResponseDto:
+    SearchToiletsResponseDto:
       type: object
       required:
         - items
@@ -6271,21 +6266,18 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/ToiletAccessibilitySummaryDto'
+            $ref: '#/components/schemas/ToiletSummaryDto'
 
-    ToiletAccessibilitySummaryDto:
+    ToiletSummaryDto:
       type: object
       required:
         - id
-        - sourceType
         - name
         - location
       properties:
         id:
           type: string
-          description: 'ToiletAccessibility ID (prefix: TA)'
-        sourceType:
-          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
+          description: 'Toilet ID (prefix: TLT)'
         name:
           type: string
         address:
@@ -6293,31 +6285,28 @@ components:
           nullable: true
         location:
           $ref: '#/components/schemas/Location'
-        thumbnailUrl:
-          type: string
-          nullable: true
 
-    GetToiletAccessibilityRequestDto:
+    GetToiletRequestDto:
       type: object
       required:
-        - toiletAccessibilityId
+        - toiletId
       properties:
-        toiletAccessibilityId:
+        toiletId:
           type: string
 
-    ToiletAccessibilityDetailDto:
+    ToiletDetailDto:
       type: object
+      description: |
+        Toilet + 병합된 소스들의 조합. 각 섹션은 데이터가 있을 때만 채워지며,
+        클라이언트는 sourceType 분기 없이 존재하는 필드만 조건부로 렌더링한다.
       required:
         - id
-        - sourceType
         - name
         - location
         - images
       properties:
         id:
           type: string
-        sourceType:
-          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
         name:
           type: string
         address:
@@ -6327,24 +6316,26 @@ components:
           $ref: '#/components/schemas/Location'
         images:
           type: array
+          description: '병합된 모든 소스의 이미지 합본'
           items:
             $ref: '#/components/schemas/ImageDto'
         locationComment:
           type: string
           nullable: true
-          description: '화장실 위치 설명 (USER 소스)'
+          description: '화장실 위치 설명 (유저 리뷰 소스가 있으면)'
         comment:
           type: string
           nullable: true
-          description: '기타 참고사항 (USER 소스)'
+          description: '기타 참고사항 (유저 리뷰 소스가 있으면)'
         toiletDetails:
           $ref: '#/components/schemas/ToiletAccessibilityDetails'
           nullable: true
-          description: 'EXTERNAL 소스 상세 필드'
+          description: '공공데이터 소스 상세 필드 (있으면)'
         referenceTargetId:
           type: string
           nullable: true
-          description: 'USER 소스의 placeId/buildingId (앱에서 PDP 이동 보조)'
+          description:
+            '유저 리뷰 소스의 placeId/buildingId (앱에서 PDP 이동 보조)'
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6322,7 +6322,8 @@ components:
           $ref: '#/components/schemas/Location'
         accessibilities:
           type: array
-          description: '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터)의 접근성 정보'
+          description:
+            '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터)의 접근성 정보'
           items:
             $ref: '#/components/schemas/ToiletAccessibilityDto'
 
@@ -6338,10 +6339,12 @@ components:
       properties:
         id:
           type: string
-          description: '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
+          description:
+            '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
         images:
           type: array
-          description: '이 소스의 이미지들 (공공데이터는 0~1장, 유저 리뷰는 0~N장)'
+          description:
+            '이 소스의 이미지들 (공공데이터는 0~1장, 유저 리뷰는 0~N장)'
           items:
             $ref: '#/components/schemas/ImageDto'
         locationComment:
@@ -6355,7 +6358,8 @@ components:
         toiletLocationType:
           type: string
           nullable: true
-          description: '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
+          description:
+            '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
         toiletDetails:
           $ref: '#/components/schemas/ToiletAccessibilityDetails'
           nullable: true

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -3595,6 +3595,12 @@ components:
           description: 장소의 종류
         toilet_details:
           $ref: '#/components/schemas/ToiletAccessibilityDetails'
+        toiletId:
+          type: string
+          nullable: true
+          description:
+            '병합된 통합 화장실(Toilet) ID. 동기화된 TOILET 카테고리 데이터에만
+            존재. 상세 이동(getToilet) 시 사용.'
       required:
         - id
         - name

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2030,6 +2030,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetSccContentDetailsResponseDto'
 
+  /searchToiletAccessibilities:
+    post:
+      tags:
+        - toilet-accessibility
+      summary: 통합 화장실 접근성 정보를 위치 기반으로 검색한다.
+      description: |
+        isSearchable=true 인 ToiletAccessibility를 위치 기반 nearest-N으로 반환한다.
+        공공데이터(ExternalAccessibility)와 유저 등록(ToiletReview) 두 소스를 통합하여 제공한다.
+      operationId: searchToiletAccessibilities
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchToiletAccessibilitiesRequestDto'
+      responses:
+        '200':
+          description: 통합 화장실 검색 결과 (isSearchable=true만, nearest-N)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchToiletAccessibilitiesResponseDto'
+
+  /getToiletAccessibility:
+    post:
+      tags:
+        - toilet-accessibility
+      summary: 통합 화장실 접근성 상세 정보를 조회한다.
+      operationId: getToiletAccessibility
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetToiletAccessibilityRequestDto'
+      responses:
+        '200':
+          description: 통합 화장실 상세 정보
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToiletAccessibilityDetailDto'
+
 components:
   parameters:
     SccCommonHeaders:
@@ -4199,6 +4242,10 @@ components:
           type: array
           items:
             type: string
+        locationComment:
+          type: string
+          nullable: true
+          description: "화장실 위치 설명 (기타 참고사항과 별도)"
         comment:
           type: string
           description: 화장실에 대해 자세히 알려주세요
@@ -4976,6 +5023,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntranceDoorType'
+        locationComment:
+          type: string
+          nullable: true
+          description: "화장실 위치 설명 (기타 참고사항과 별도)"
         comment:
           type: string
         images:
@@ -6188,6 +6239,112 @@ components:
       required:
         - totalCount
         - isUpvoted
+
+    ToiletAccessibilitySourceTypeDto:
+      type: string
+      description: "화장실 접근성 데이터 소스 타입"
+      enum:
+        - USER_TOILET_REVIEW
+        - EXTERNAL_ACCESSIBILITY
+
+    SearchToiletAccessibilitiesRequestDto:
+      type: object
+      required:
+        - currentLocation
+      properties:
+        currentLocation:
+          $ref: '#/components/schemas/Location'
+        limit:
+          type: integer
+          default: 50
+          description: "nearest-N 개수 (기본 50)"
+        distanceMetersLimit:
+          type: integer
+          nullable: true
+          description: "최대 반경 (미터). 없으면 limit만 적용"
+
+    SearchToiletAccessibilitiesResponseDto:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToiletAccessibilitySummaryDto'
+
+    ToiletAccessibilitySummaryDto:
+      type: object
+      required:
+        - id
+        - sourceType
+        - name
+        - location
+      properties:
+        id:
+          type: string
+          description: "ToiletAccessibility ID (prefix: TA)"
+        sourceType:
+          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
+        name:
+          type: string
+        address:
+          type: string
+          nullable: true
+        location:
+          $ref: '#/components/schemas/Location'
+        thumbnailUrl:
+          type: string
+          nullable: true
+
+    GetToiletAccessibilityRequestDto:
+      type: object
+      required:
+        - toiletAccessibilityId
+      properties:
+        toiletAccessibilityId:
+          type: string
+
+    ToiletAccessibilityDetailDto:
+      type: object
+      required:
+        - id
+        - sourceType
+        - name
+        - location
+        - images
+      properties:
+        id:
+          type: string
+        sourceType:
+          $ref: '#/components/schemas/ToiletAccessibilitySourceTypeDto'
+        name:
+          type: string
+        address:
+          type: string
+          nullable: true
+        location:
+          $ref: '#/components/schemas/Location'
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageDto'
+        locationComment:
+          type: string
+          nullable: true
+          description: "화장실 위치 설명 (USER 소스)"
+        comment:
+          type: string
+          nullable: true
+          description: "기타 참고사항 (USER 소스)"
+        toiletDetails:
+          $ref: '#/components/schemas/ToiletAccessibilityDetails'
+          nullable: true
+          description: "EXTERNAL 소스 상세 필드"
+        referenceTargetId:
+          type: string
+          nullable: true
+          description: "USER 소스의 placeId/buildingId (앱에서 PDP 이동 보조)"
 
   responses:
     ApiFailure:

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6303,13 +6303,13 @@ components:
     ToiletDetailDto:
       type: object
       description: |
-        Toilet + 병합된 소스들의 조합. 각 섹션은 데이터가 있을 때만 채워지며,
-        클라이언트는 sourceType 분기 없이 존재하는 필드만 조건부로 렌더링한다.
+        통합 Toilet + 병합된 소스별 접근성 정보 리스트. PDP(Place + PlaceAccessibility[]) 패턴.
+        Toilet 레벨 식별/표시 정보 + 소스별 ToiletAccessibilityDto 배열로 구성된다.
       required:
         - id
         - name
         - location
-        - images
+        - accessibilities
       properties:
         id:
           type: string
@@ -6320,23 +6320,46 @@ components:
           nullable: true
         location:
           $ref: '#/components/schemas/Location'
+        accessibilities:
+          type: array
+          description: '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터)의 접근성 정보'
+          items:
+            $ref: '#/components/schemas/ToiletAccessibilityDto'
+
+    ToiletAccessibilityDto:
+      type: object
+      description: |
+        Toilet에 병합된 단일 소스(유저 리뷰 ToiletReview 또는 공공데이터 ExternalAccessibility)의 접근성 정보.
+        소스 종류에 따라 채워지는 필드가 다르며, 클라이언트는 sourceType 분기 없이
+        존재하는 필드만 조건부로 렌더링한다.
+      required:
+        - id
+        - images
+      properties:
+        id:
+          type: string
+          description: '소스 엔티티 id (ToiletReview 또는 ExternalAccessibility)'
         images:
           type: array
-          description: '병합된 모든 소스의 이미지 합본'
+          description: '이 소스의 이미지들 (공공데이터는 0~1장, 유저 리뷰는 0~N장)'
           items:
             $ref: '#/components/schemas/ImageDto'
         locationComment:
           type: string
           nullable: true
-          description: '화장실 위치 설명 (유저 리뷰 소스가 있으면)'
+          description: '화장실 위치 설명 (유저 리뷰 소스)'
         comment:
           type: string
           nullable: true
-          description: '기타 참고사항 (유저 리뷰 소스가 있으면)'
+          description: '기타 참고사항 (유저 리뷰 소스)'
+        toiletLocationType:
+          type: string
+          nullable: true
+          description: '화장실 위치 유형 PLACE/BUILDING/NONE/ETC (유저 리뷰 소스)'
         toiletDetails:
           $ref: '#/components/schemas/ToiletAccessibilityDetails'
           nullable: true
-          description: '공공데이터 소스 상세 필드 (있으면)'
+          description: '공공데이터 소스 상세 필드'
         referenceTargetId:
           type: string
           nullable: true


### PR DESCRIPTION
## Summary
- `RegisterToiletReviewRequestDto` / `ToiletReviewDto`에 `locationComment` 필드 추가 (피드백 4: 위치 설명 분리)
- `POST /searchToiletAccessibilities` — 통합 화장실 위치 기반 nearest-N 검색 (isSearchable=true 필터)
- `POST /getToiletAccessibility` — 통합 화장실 상세 조회 (TDP용)
- Admin: `POST /toilet-accessibilities/search` — 큐레이션 큐 조회
- Admin: `POST /toilet-accessibilities/{id}/set-searchable` — isSearchable 토글

## 신규 스키마
`ToiletAccessibilitySourceTypeDto`, `ToiletAccessibilitySummaryDto`, `ToiletAccessibilityDetailDto`, `SearchToiletAccessibilitiesRequestDto`, `SearchToiletAccessibilitiesResponseDto`, `AdminToiletAccessibilityDto`, `AdminToiletReviewDetailDto` 등

## 관련 스펙
`specs/toilet-accessibility-source-integration.md` Phase 0 (locationComment) + Phase 2 (검색/상세 API) + Admin (큐레이션 API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)