### PR TITLE
feat: 외부 지도앱 공유하기 → PDP 랜딩 API 스펙 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1479,6 +1479,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchPlacesResponseDto'
 
+  /resolveSharedPlaceLink:
+    post:
+      summary: 외부 지도앱에서 공유된 텍스트를 해석해 내부 장소로 매핑한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResolveSharedPlaceLinkRequestDto'
+      responses:
+        '200':
+          description: 해석 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResolveSharedPlaceLinkResponseDto'
+
   /searchUnconqueredPlacesNearby:
     post:
       summary: 정복 안 된 장소를 검색한다.
@@ -4324,6 +4341,53 @@ components:
             #   type: string
             #   description: AI 분석 결과 요약
           # required: []
+
+    ResolveSharedPlaceLinkRequestDto:
+      type: object
+      properties:
+        sharedText:
+          type: string
+          description:
+            외부 앱이 공유 시트로 넘긴 원문 텍스트 전체(URL 포함). 서버가
+            파싱한다.
+      required:
+        - sharedText
+
+    ResolveSharedPlaceLinkResultStatusDto:
+      type: string
+      enum:
+        - MATCHED
+        - AMBIGUOUS
+        - NOT_FOUND
+
+    SharedPlaceLinkVendorDto:
+      type: string
+      enum:
+        - KAKAO
+        - NAVER
+        - GOOGLE
+        - TMAP
+        - UNKNOWN
+
+    ResolveSharedPlaceLinkResponseDto:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ResolveSharedPlaceLinkResultStatusDto'
+        place:
+          $ref: '#/components/schemas/PlaceListItem'
+        candidates:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceListItem'
+        fallbackQuery:
+          type: string
+          description: status=NOT_FOUND 일 때 Search 화면 prefill 용 검색어
+        detectedVendor:
+          $ref: '#/components/schemas/SharedPlaceLinkVendorDto'
+      required:
+        - status
+        - detectedVendor
 
     SuggestPlacesRequestDto:
       type: object


### PR DESCRIPTION
## Summary

- `POST /resolveSharedPlaceLink` 엔드포인트 추가
- 관련 DTO 4종 추가: `ResolveSharedPlaceLinkRequestDto`, `ResolveSharedPlaceLinkResponseDto`, `ResolveSharedPlaceLinkResultStatusDto`, `SharedPlaceLinkVendorDto`

## 배경

카카오맵·네이버지도 등 외부 지도앱에서 장소를 공유(OS 공유 시트)하면, 우리 앱이 공유 텍스트를 받아 해당 장소의 PDP(`PlaceDetailV2`)로 랜딩하는 기능을 위한 API.

## API 설계

```
POST /resolveSharedPlaceLink
  Request: { sharedText: string }  // 외부 앱이 보낸 원문 텍스트 전체
  Response: {
    status: MATCHED | AMBIGUOUS | NOT_FOUND
    place?: PlaceListItem           // MATCHED
    candidates?: PlaceListItem[]    // AMBIGUOUS
    fallbackQuery?: string          // NOT_FOUND (Search 화면 prefill용)
    detectedVendor: KAKAO | NAVER | GOOGLE | TMAP | UNKNOWN
  }
```

## 서버 처리 파이프라인

1. 텍스트에서 URL 추출 → 단축 URL redirect 추적 (SSRF allowlist)
2. 벤더 판별 + 이름/좌표 추출
3. ThirdPartyPlace 정확 매칭 → 이름 fuzzy 검색+자동생성 → NOT_FOUND 순

## 미완료

- §0 실기기 공유 페이로드 캡처 후 서버 parser regex 확정 필요 (TODO 주석 있음)
- iOS Share Extension은 별도 작업

## Test plan

- [ ] scc-server 빌드 통과 확인 (`./gradlew build`)
- [ ] scc-app codegen 통과 확인 (`yarn codegen`)
- [ ] 실기기 공유 E2E 테스트 (§0 캡처 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)