### PR TITLE
feat: ToiletSummaryDto에 accessibilities 추가 (검색 카드 정보 복원)

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6280,6 +6280,7 @@ components:
         - id
         - name
         - location
+        - accessibilities
       properties:
         id:
           type: string
@@ -6291,6 +6292,14 @@ components:
           nullable: true
         location:
           $ref: '#/components/schemas/Location'
+        accessibilities:
+          type: array
+          description:
+            '이 Toilet에 병합된 모든 소스(유저 리뷰 + 공공데이터)의 접근성 정보.
+            카드가 대표 이미지/사용가능/성별/입구 정보를 렌더하는 데 사용한다.
+            (상세 getToilet과 동일 DTO)'
+          items:
+            $ref: '#/components/schemas/ToiletAccessibilityDto'
 
     GetToiletRequestDto:
       type: object


### PR DESCRIPTION
## 배경
`/searchToilets` 결과 카드가 id/name/address/location만 받아 **이미지·사용가능·성별·입구 정보를 모두 잃고 쪼그라드는** 회귀가 발생했다. (EA 소스 화장실 카드가 기존 외부 접근성 검색 시절과 다르게 그려짐)

## 변경
- `ToiletSummaryDto`에 `accessibilities: ToiletAccessibilityDto[]` 추가 (required)
- 상세(`getToilet`)와 **동일한 DTO**를 요약에도 내려, 앱 카드가 대표 소스(이미지/사용가능/성별/입구)를 TDP와 같은 매핑 로직으로 렌더하도록 함

## Cascading
- scc-server: 검색 결과 toilet들의 소스를 배치 로드하여 summary 조립 (별도 PR)
- scc-app: `mapSummaryToToiletDetails`가 대표 accessibility를 카드 필드로 매핑 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)