### PR TITLE
feat: ToiletAccessibilityDto에 registeredUserName + createdAt 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6378,6 +6378,18 @@ components:
           nullable: true
           description:
             '유저 리뷰 소스의 placeId/buildingId (앱에서 PDP 이동 보조)'
+        registeredUserName:
+          type: string
+          nullable: true
+          description:
+            '유저 리뷰 작성자 닉네임. 익명이거나 공공데이터 소스면 null. (유저
+            리뷰 소스)'
+        createdAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+          nullable: true
+          description:
+            '소스 등록 시점. 유저 리뷰 소스에만 존재하고 공공데이터 소스면 null.
+            (유저 리뷰 소스)'
 
   responses:
     ApiFailure:


### PR DESCRIPTION
## 개요
화장실 상세(getToilet)에서 유저 리뷰의 **등록자 닉네임 / 등록 시점**을 표시하기 위해 `ToiletAccessibilityDto`에 두 필드를 추가한다.

## 변경
- `registeredUserName` (string, nullable): 유저 리뷰 작성자 닉네임. 익명이거나 공공데이터 소스면 null.
- `createdAt` (EpochMillisTimestamp, nullable): 소스 등록 시점. 공공데이터 소스면 null.

둘 다 optional/nullable이라 기존 클라이언트와 하위 호환된다.

## 다운스트림
- scc-server: Converter에서 닉네임/시점 매핑 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)