### PR TITLE
feat: 추천 칩 discovery(type)/navigation(navigationType) 분리

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6444,9 +6444,17 @@ components:
 
     PlaceSearchRecommendationTypeDto:
       type: string
-      description: 장소 검색 추천 타입 (클라이언트에 노출되는 컨텐츠 타입)
+      description:
+        '장소 검색 추천의 discovery 타입 — 추천이 어떻게 만들어지고 매칭됐는지를 나타낸다.
+        칩의 비주얼 디자인을 결정한다. 탭 시 랜딩은 navigationType이 결정(직교한 별도 차원).'
       enum:
-        - PLACE_LIST
+        - REGION_BASED # 지도 영역(폴리곤) 기반 추천
+
+    PlaceSearchRecommendationNavigationTypeDto:
+      type: string
+      description: 장소 검색 추천 칩 탭 시 랜딩(navigation) 타입
+      enum:
+        - PLACE_LIST # 저장리스트 상세로 이동
 
     PlaceSearchRecommendationDto:
       type: object
@@ -6456,6 +6464,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/PlaceSearchRecommendationTypeDto'
+        navigationType:
+          $ref: '#/components/schemas/PlaceSearchRecommendationNavigationTypeDto'
         name:
           type: string
           maxLength: 8
@@ -6463,10 +6473,11 @@ components:
         placeListId:
           type: string
           nullable: true
-          description: PLACE_LIST 타입일 때 탭 시 이동할 저장리스트 ID
+          description: navigationType이 PLACE_LIST일 때 탭 시 이동할 저장리스트 ID
       required:
         - id
         - type
+        - navigationType
         - name
 
     ListPlaceSearchRecommendationsRequestDto:


### PR DESCRIPTION
## 배경

`PlaceSearchRecommendation`의 두 관심사가 한 필드(`type`)에 뭉쳐 있었다.

- **REGION_BASED** — 추천을 *어떻게 만들고 매칭하는지* (discovery). 서버 도메인 `PlaceSearchRecommendationType`.
- **PLACE_LIST** — 탭 시 *어디로 랜딩시킬지* (navigation).

이 둘은 직교한 관심사인데, 기존 클라 스펙은 `type: [PLACE_LIST]` 하나로만 두고 서버 컨버터가 `REGION_BASED → PLACE_LIST`로 매핑해 discovery 정보를 잃었다. 그 결과 클라가 추천 칩의 비주얼(지역 기반 핀 디자인)을 discovery 타입 기준으로 분기할 수 없었다.

## 변경

`PlaceSearchRecommendationDto`를 두 필드로 분리:

- `type: PlaceSearchRecommendationTypeDto` enum `[REGION_BASED]` — discovery. 서버 도메인과 1:1. 칩 비주얼 디자인 결정.
- `navigationType: PlaceSearchRecommendationNavigationTypeDto` enum `[PLACE_LIST]` (신규) — navigation. 탭 시 랜딩 결정.
- `placeListId`는 `navigationType==PLACE_LIST`일 때 이동 대상.

다운스트림(scc-server 컨버터, scc-app 칩 렌더/네비게이션)은 후속 PR에서 cascading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)