### PR TITLE
feat: Place에 displayCategoryName 필드 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -3454,6 +3454,9 @@ components:
           $ref: '#/components/schemas/Location'
         category:
           $ref: '#/components/schemas/PlaceCategoryDto'
+        displayCategoryName:
+          type: string
+          description: vendor 원본 데이터에서 추출한 세부 카테고리명(e.g. "육류,고기"). 없으면 category 기반 라벨로 표시한다.
         isFavorite:
           type: boolean
           description: 내가 즐겨찾기한 점포인지 여부.


### PR DESCRIPTION
## 개요

장소 카테고리를 앱에서 더 세분화해 보여주기 위해 `Place` 스키마에 optional `displayCategoryName` 필드를 추가한다.

현재는 `category`(18종 enum)만 노출돼 "식당"·"카페"처럼 뭉뚱그려진다. vendor 원본(`third_party_place.rawData`)에는 훨씬 세부적인 카테고리(KAKAO `categoryName` "음식점 > 한식 > 국수", NAVER `category`, TMAP `lowerBizName`)가 있어, 그 leaf를 추출해 `displayCategoryName`에 담는다. 앱은 `displayCategoryName` 우선, 없으면 기존 `category` 기반 라벨로 fallback.

## 변경

- `api-spec.yaml` `Place` 스키마에 `displayCategoryName: string` (optional) 추가

## 다운스트림

- scc-server: 컬럼 추가 + 추출 로직 + 백필 배치 (별도 PR)
- scc-app: `displayCategoryName` 우선 표시 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)