### PR TITLE
feat(user): mobilityTools enum에 이동유형 7종 추가 (signup-improvement)

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4685,6 +4685,13 @@ components:
         - CLUCH # 클러치(목발, 지팡이)
         - NONE # 해당사항없음
         - FRIEND_OF_TOOL_USER # 도구를 사용하는 사람의 친구
+        - SCOOTER # 스쿠터
+        - WHEELCHAIR_USER_COMPANION # 휠체어 사용자의 가족·친구·동료
+        - WALKER # 워커
+        - CANE # 지팡이
+        - WALKING_CART # 보행차
+        - CRUTCH # 목발
+        - WALKING_DIFFICULTY # 보행 대체·보조 기기가 없으나 보행 불편
 
     UpvotedPlaceDto:
       type: object


### PR DESCRIPTION
## 개요
회원가입 플로우 개선의 일부. Step 3 이동유형 선택 분류 세분화를 위해 `UserMobilityToolDto` enum에 신규 7값을 추가한다.

## 변경
- `api-spec.yaml` `UserMobilityToolDto` enum에 추가:
  - `SCOOTER` (스쿠터)
  - `WHEELCHAIR_USER_COMPANION` (휠체어 사용자의 가족·친구·동료)
  - `WALKER` (워커)
  - `CANE` (지팡이)
  - `WALKING_CART` (보행차)
  - `CRUTCH` (목발)
  - `WALKING_DIFFICULTY` (보행 대체·보조 기기가 없으나 보행 불편)
- 기존 9값은 하위호환 위해 유지(삭제·순서변경 없음). DB는 enum name TEXT 저장이라 마이그레이션 불필요.

## Spec
`specs/signup-improvement/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)