### PR TITLE
feat: 화장실 출처/확인시각/개방시간/전화번호 필드 추가

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,7 @@ OpenAPI 3.0 스펙 (Source of Truth). YAML 작성 절차/예제/패턴은 `/scc-
 
 ## Schema Reusability
 
+- **유한한 값 집합(출처/타입/상태 코드)은 free string이 아니라 enum Dto로 정의** (예: `AccessibilitySourceDto`). 코드값을 string + description으로 나열하지 않는다. (PR #119)
 - 관련 필드는 flat 나열 대신 별도 DTO로 묶고, 동일 enum이 3곳 이상 반복되면 별도 스키마로 분리해 `$ref` 참조
 - 새 스키마 작성 전 기존 `components/schemas`에서 재사용 가능한 것을 먼저 검색
 - 표준 Register Request/Response 구조와 예시는 `/scc-api-spec-design` 참조

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -3456,7 +3456,9 @@ components:
           $ref: '#/components/schemas/PlaceCategoryDto'
         displayCategoryName:
           type: string
-          description: vendor 원본 데이터에서 추출한 세부 카테고리명(e.g. "육류,고기"). 없으면 category 기반 라벨로 표시한다.
+          description:
+            vendor 원본 데이터에서 추출한 세부 카테고리명(e.g. "육류,고기").
+            없으면 category 기반 라벨로 표시한다.
         isFavorite:
           type: boolean
           description: 내가 즐겨찾기한 점포인지 여부.
@@ -3632,7 +3634,8 @@ components:
         lastVerifiedAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
           nullable: true
-          description: '공공데이터 소스의 마지막 확인/수정 시각 (updatedAt 기반).'
+          description:
+            '공공데이터 소스의 마지막 확인/수정 시각 (updatedAt 기반).'
       required:
         - id
         - name
@@ -3669,7 +3672,9 @@ components:
         openingHours:
           type: string
           nullable: true
-          description: '화장실 개방시간 (예: "월-금 06:00~22:00"). 공공데이터 소스에만 존재.'
+          description:
+            '화장실 개방시간 (예: "월-금 06:00~22:00"). 공공데이터 소스에만
+            존재.'
         phoneNumber:
           type: string
           nullable: true
@@ -6454,11 +6459,15 @@ components:
         source:
           $ref: '#/components/schemas/AccessibilitySourceDto'
           nullable: true
-          description: '데이터 출처. 유저 리뷰 소스는 null. 표시명(humanReadable)은 클라이언트가 매핑.'
+          description:
+            '데이터 출처. 유저 리뷰 소스는 null. 표시명(humanReadable)은
+            클라이언트가 매핑.'
         lastVerifiedAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
           nullable: true
-          description: '화장실 정보가 마지막으로 확인된 시각(공공데이터 소스의 updatedAt). 유저 리뷰 소스는 null.'
+          description:
+            '화장실 정보가 마지막으로 확인된 시각(공공데이터 소스의 updatedAt).
+            유저 리뷰 소스는 null.'
 
     PlaceTagTypeDto:
       type: string
@@ -6486,8 +6495,9 @@ components:
     PlaceSearchRecommendationTypeDto:
       type: string
       description:
-        '장소 검색 추천의 discovery 타입 — 추천이 어떻게 만들어지고 매칭됐는지를 나타낸다.
-        칩의 비주얼 디자인을 결정한다. 탭 시 랜딩은 navigationType이 결정(직교한 별도 차원).'
+        '장소 검색 추천의 discovery 타입 — 추천이 어떻게 만들어지고 매칭됐는지를
+        나타낸다. 칩의 비주얼 디자인을 결정한다. 탭 시 랜딩은 navigationType이
+        결정(직교한 별도 차원).'
       enum:
         - REGION_BASED # 지도 영역(폴리곤) 기반 추천
 
@@ -6514,7 +6524,8 @@ components:
         placeListId:
           type: string
           nullable: true
-          description: navigationType이 PLACE_LIST일 때 탭 시 이동할 저장리스트 ID
+          description:
+            navigationType이 PLACE_LIST일 때 탭 시 이동할 저장리스트 ID
       required:
         - id
         - type

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -3625,6 +3625,14 @@ components:
           description:
             '병합된 통합 화장실(Toilet) ID. 동기화된 TOILET 카테고리 데이터에만
             존재. 상세 이동(getToilet) 시 사용.'
+        source:
+          type: string
+          nullable: true
+          description: '데이터 출처 소스 코드 (예: SMART_SEOUL_MAP, MOIS_PUBLIC_TOILET). null이면 출처 미상.'
+        lastVerifiedAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+          nullable: true
+          description: '공공데이터 소스의 마지막 확인/수정 시각 (updatedAt 기반).'
       required:
         - id
         - name
@@ -3658,6 +3666,14 @@ components:
           type: string
         extraDesc:
           type: string
+        openingHours:
+          type: string
+          nullable: true
+          description: '화장실 개방시간 (예: "월-금 06:00~22:00"). 공공데이터 소스에만 존재.'
+        phoneNumber:
+          type: string
+          nullable: true
+          description: '관리기관 전화번호. 공공데이터 소스에만 존재.'
 
     PlaceListItem:
       type: object
@@ -6428,6 +6444,14 @@ components:
           description:
             '소스 등록 시점. 유저 리뷰 소스에만 존재하고 공공데이터 소스면 null.
             (유저 리뷰 소스)'
+        sourceName:
+          type: string
+          nullable: true
+          description: '출처 표시명 (예: "스마트서울맵", "행정안전부 전국공중화장실표준데이터"). 유저 리뷰 소스는 null.'
+        lastVerifiedAt:
+          $ref: '#/components/schemas/EpochMillisTimestamp'
+          nullable: true
+          description: '화장실 정보가 마지막으로 확인된 시각(공공데이터 소스의 updatedAt). 유저 리뷰 소스는 null.'
 
     PlaceTagTypeDto:
       type: string

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -3626,9 +3626,9 @@ components:
             '병합된 통합 화장실(Toilet) ID. 동기화된 TOILET 카테고리 데이터에만
             존재. 상세 이동(getToilet) 시 사용.'
         source:
-          type: string
+          $ref: '#/components/schemas/AccessibilitySourceDto'
           nullable: true
-          description: '데이터 출처 소스 코드 (예: SMART_SEOUL_MAP, MOIS_PUBLIC_TOILET). null이면 출처 미상.'
+          description: '데이터 출처. null이면 출처 미상.'
         lastVerifiedAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
           nullable: true
@@ -5070,6 +5070,13 @@ components:
         - NONE # 없음
         - ETC # 기타
 
+    AccessibilitySourceDto:
+      type: string
+      description: 접근성 데이터 출처
+      enum:
+        - SMART_SEOUL_MAP # 스마트서울맵
+        - MOIS_PUBLIC_TOILET # 행정안전부 전국공중화장실표준데이터
+
     ToiletReviewDto:
       type: object
       properties:
@@ -6444,10 +6451,10 @@ components:
           description:
             '소스 등록 시점. 유저 리뷰 소스에만 존재하고 공공데이터 소스면 null.
             (유저 리뷰 소스)'
-        sourceName:
-          type: string
+        source:
+          $ref: '#/components/schemas/AccessibilitySourceDto'
           nullable: true
-          description: '출처 표시명 (예: "스마트서울맵", "행정안전부 전국공중화장실표준데이터"). 유저 리뷰 소스는 null.'
+          description: '데이터 출처. 유저 리뷰 소스는 null. 표시명(humanReadable)은 클라이언트가 매핑.'
         lastVerifiedAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
           nullable: true


### PR DESCRIPTION
## 개요
전국 장애인화장실 공공데이터(행정안전부) 적재를 위한 API 스펙 변경. 화장실 접근성 정보에 **출처**와 **마지막 확인 시각**, 그리고 공공데이터 부가정보(개방시간/전화번호)를 노출한다.

## 변경 (api-spec.yaml, 전부 nullable — 하위호환)
- `ToiletAccessibilityDetails`: `openingHours`, `phoneNumber` 추가
- `ToiletAccessibilityDto`: `sourceName`(출처 표시명), `lastVerifiedAt`(EpochMillisTimestamp) 추가
- `ExternalAccessibility`: `source`, `lastVerifiedAt` 추가

## 설계 노트
- 앱은 `sourceType` 분기 없이 **존재하는 필드만 조건부 렌더링**하는 기존 시맨틱 유지. `sourceName`/`lastVerifiedAt`은 표시 메타데이터일 뿐 렌더링 분기 키가 아니다.
- spec: `specs/national-public-toilet/spec.md`

## 다운스트림
- scc-server: `feat/national-public-toilet` (ToiletConverter 매핑 + MOIS 적재)
- scc-app: `feat/national-public-toilet` (카드/TDP 렌더링)

🤖 Generated with [Claude Code](https://claude.com/claude-code)