### PR TITLE
feat(user): UserMobilityToolDto enum 정리 (동반자 FRIEND_OF_* 통일 + 워커·보행차 통합)

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4705,13 +4705,12 @@ components:
         - WALKING_ASSISTANCE_DEVICE # 보행보조기구
         - CLUCH # 클러치(목발, 지팡이)
         - NONE # 해당사항없음
-        - FRIEND_OF_TOOL_USER # 도구를 사용하는 사람의 친구
-        - SCOOTER # 스쿠터
-        - WHEELCHAIR_USER_COMPANION # 휠체어 사용자의 가족·친구·동료
-        - WALKER # 워커
+        - FRIEND_OF_WHEELCHAIR_USER # 휠체어 사용자의 가족·친구·동료
+        - SCOOTER # 전동스쿠터(의료용)
         - CANE # 지팡이
-        - WALKING_CART # 보행차
+        - WALKER_AND_WALKING_CART # 워커·보행차
         - CRUTCH # 목발
+        - FRIEND_OF_WALKING_AID_USER # 보행 보조 기기 사용자의 가족·친구·동료
         - WALKING_DIFFICULTY # 보행 대체·보조 기기가 없으나 보행 불편
 
     UpvotedPlaceDto:


### PR DESCRIPTION
## 배경
회원가입 개선 Figma(node 2439:35046) 재검토 결과, 이동수단 선택지의 enum을 정리한다.

## 변경 (`UserMobilityToolDto`)
- `FRIEND_OF_TOOL_USER` → **`FRIEND_OF_WHEELCHAIR_USER`** (rename, 의미: 휠체어 사용자의 가족·친구·동료)
- `WHEELCHAIR_USER_COMPANION` **제거** → 위로 통합
- `WALKER` + `WALKING_CART` **제거** → **`WALKER_AND_WALKING_CART`** 신규
- `FRIEND_OF_WALKING_AID_USER` **신규** (보행 보조 기기 사용자의 가족·친구·동료)
- 동반자 계열을 `FRIEND_OF_*` 로 통일, 중복 제거.

## 다운스트림
- scc-server: 도메인 enum + 컨버터 + 데이터 마이그레이션(별도 PR)
- scc-app: codegen + UI(별도 PR)
- 하위호환 유지 안 함 (제품 결정 2026-06-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)