### PR TITLE
feat(place): 폐업 후보 DTO에 checkSource/closureReason/matchConfidence 추가

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -3426,9 +3426,50 @@ components:
           $ref: '#/components/schemas/EpochMillisTimestamp'
         ignoredAt:
           $ref: '#/components/schemas/EpochMillisTimestamp'
+        checkSource:
+          $ref: '#/components/schemas/AdminClosureCheckSourceDTO'
+        closureReason:
+          $ref: '#/components/schemas/AdminClosureReasonDTO'
+        matchConfidence:
+          type: number
+          format: double
+          description: 매칭 신뢰도 (0.0~1.0). 낮은 신뢰도로 폐업 추정된 경우 등에 설정, 없으면 null.
       required:
         - id
         - placeId
+        - checkSource
+
+    AdminClosureCheckSourceDTO:
+      type: string
+      description: |
+        폐업 추정 소스 (어떤 방식으로 확인했는지)
+        - NAVER_MAPS_API: 네이버 지도 API 검색
+        - NAVER_PLACE_CRAWLER: 네이버 플레이스 크롤링
+        - PUBLIC_DATA: 공공데이터 폐업 정보
+        - KAKAO / GOOGLE / TMAP: 각 지도 서비스
+        - MANUAL: 관리자 수동 입력
+      enum:
+        - NAVER_MAPS_API
+        - NAVER_PLACE_CRAWLER
+        - PUBLIC_DATA
+        - KAKAO
+        - GOOGLE
+        - TMAP
+        - MANUAL
+
+    AdminClosureReasonDTO:
+      type: string
+      description: |
+        폐업 추정 근거 (왜 폐업으로 추정했는지)
+        - CLOSED_BY_PUBLIC_DATA: 공공데이터에서 폐업 확인
+        - NOT_FOUND_ON_MAP: 지도에서 검색 결과 없음
+        - LOW_MATCH_CONFIDENCE: 검색 결과와 일치도 낮음
+        - MANUAL_CHECK: 관리자 수동 확인
+      enum:
+        - CLOSED_BY_PUBLIC_DATA
+        - NOT_FOUND_ON_MAP
+        - LOW_MATCH_CONFIDENCE
+        - MANUAL_CHECK
 
     AdminBuildingDivisionStatusDTO:
       type: string


### PR DESCRIPTION
## 배경

어드민 폐업 후보 목록(`/admin/closed-place-candidates`)에 어떤 소스(네이버 지도 API / 네이버 크롤러 / 공공데이터 / 카카오 등)로, 어떤 근거로 폐업 추정됐는지가 안 보여서 운영자가 오탐을 감사할 수 없었다.

## 변경

`AdminClosedPlaceCandidateDTO`에 필드 추가:
- `checkSource` (required) — `AdminClosureCheckSourceDTO` enum (NAVER_MAPS_API/NAVER_PLACE_CRAWLER/PUBLIC_DATA/KAKAO/GOOGLE/TMAP/MANUAL)
- `closureReason` (optional) — `AdminClosureReasonDTO` enum (CLOSED_BY_PUBLIC_DATA/NOT_FOUND_ON_MAP/LOW_MATCH_CONFIDENCE/MANUAL_CHECK)
- `matchConfidence` (optional) — 매칭 신뢰도

## Cascading (필수)

- scc-server: submodule bump → openApiGenerate → Converter/DTO 매핑
- scc-admin: submodule bump → codegen → 목록 UI에 소스/근거 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)