### PR TITLE
feat(api): 튜토리얼 미션 v2 — VIEW_TUTORIAL_IMAGES 미션 타입 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1897,6 +1897,7 @@ paths:
         미션별 추가 컨텍스트(예: SAVE_PLACE_LIST 의 placeListId)는 동일 body 에 함께 전달한다.
 
         서버 검증 (미션 타입별):
+        - VIEW_TUTORIAL_IMAGES: 추가 검증 없음 (앱이 튜토리얼 이미지 마지막 장 CTA에서 호출).
         - REGISTER_INTERESTED_REGIONS_AND_THEMES: 추가 검증 없음 (클라이언트가 등록 직후 호출).
         - SAVE_PLACE_LIST: 추가 검증 없음 (클라이언트가 저장 직후 placeListId 와 함께 호출).
         - UPVOTE_ACCESSIBILITY: 추가 검증 없음 (가짜 PDP 에서 사용자 명시 액션 후 호출되므로).
@@ -6106,18 +6107,21 @@ components:
       type: object
       description: |
         윌리의 외출 NUX 튜토리얼 미션 진행 상태.
-        missions 배열은 TutorialMissionTypeDto 선언 순서대로 4개 (3 main + 1 hidden) 포함된다.
+        서버가 내려주는 missions 배열 순서가 곧 미션 순서다. 항상 4개(main 3 + hidden 1)를
+        포함하며, HIDDEN_APP_SURVEY를 제외한 3개가 메인 미션이다. 가입 시점에 따라
+        미션 구성/순서가 다를 수 있다.
       properties:
         missions:
           type: array
           description:
-            TutorialMissionTypeDto 선언 순서대로 4개 (3 main + 1 hidden) 미션의
-            진행 상태
+            서버가 내려주는 배열 순서가 곧 미션 순서다. 항상 4개(main 3 + hidden
+            1)를 포함하며, HIDDEN_APP_SURVEY를 제외한 3개가 메인 미션이다. 가입
+            시점에 따라 미션 구성/순서가 다를 수 있다.
           items:
             $ref: '#/components/schemas/UserTutorialMissionDto'
         currentMissionType:
           description: |
-            현재 사용자가 다음으로 완료해야 하는 미션. 미션 선언 순서대로 첫 번째
+            현재 사용자가 다음으로 완료해야 하는 미션. 미션 배열 순서상 첫 번째
             미완료 미션을 가리킨다. 모든 미션이 완료되었거나 익명 사용자처럼
             진행 상태를 알 수 없는 경우 null.
           nullable: true
@@ -6172,9 +6176,12 @@ components:
       type: string
       description: |
         윌리의 외출 NUX 튜토리얼 미션 종류.
-        HIDDEN_APP_SURVEY가 히든 미션(앱 사용 후기 설문)이며, 나머지 3개가 메인 미션이다.
-        UserTutorialProgressDto.missions 배열은 이 enum 선언 순서대로 4개를 모두 포함한다.
+        HIDDEN_APP_SURVEY가 히든 미션(앱 사용 후기 설문)이며, 나머지가 메인 미션이다.
+        이 enum 선언 순서는 미션 순서를 의미하지 않는다. 미션 순서는
+        UserTutorialProgressDto.missions 배열 순서를 따르며, 사용자의 가입 시점에 따라
+        서로 다른 미션 셋(v1/v2)이 내려온다. 클라이언트는 순서를 하드코딩하지 않는다.
       enum:
+        - VIEW_TUTORIAL_IMAGES
         - REGISTER_INTERESTED_REGIONS_AND_THEMES
         - SAVE_PLACE_LIST
         - UPVOTE_ACCESSIBILITY


### PR DESCRIPTION
## 배경

NUX 튜토리얼("윌리의 외출")의 미션 1이 "관심 지역/주제 등록"이라 폼 작성이라는 진입 장벽이 있어 미션 2 전환율이 낮다. 미션 1을 **읽기만 하면 끝나는 튜토리얼 이미지 3장 보기**로 교체해 진입과 거의 동시에 첫 미션을 클리어시킨다.

| | v1 (기존 가입자) | v2 (신규 가입자) |
|---|---|---|
| 미션 1 | 관심 지역/주제 등록 | **튜토리얼 이미지 확인하기** ← 신규 |
| 미션 2 | 저장리스트 저장 | 관심 지역/주제 등록 |
| 미션 3 | 상세정보 도움이 돼요 | 저장리스트 저장 |
| 히든 | 앱 사용 후기 설문 | 동일 |

이미 진행 중이던 유저의 미션이 바뀌면 안 되므로, **가입일 컷오프 이후 가입자에게만 v2**를 적용한다. 두 미션 셋이 1주일 정도 공존한다.

- Figma: https://www.figma.com/design/cpDrl9uG7RMjT5TvTGme3K/?node-id=2586-27275
- spec: `specs/tutorial-mission-v2/spec.md` (scc-workspace)

## 변경 내용

- `TutorialMissionTypeDto` enum 맨 앞에 `VIEW_TUTORIAL_IMAGES` 추가
- **`enum 선언 순서 = 미션 순서` 전제를 폐기**하고 description 정정 — 미션 순서는 `UserTutorialProgressDto.missions` **배열 순서**를 따르며, 가입 시점에 따라 서로 다른 셋이 내려온다. 클라이언트는 순서를 하드코딩하지 않는다.
- `UserTutorialProgressDto` / `missions` / `currentMissionType` description 정정
- `/completeUserTutorialMission` 의 미션별 서버 검증 목록에 `VIEW_TUTORIAL_IMAGES` 항목 추가

## 하위 호환

기존 enum 값 4개와 그 순서는 그대로다. 필드 추가/삭제/`required` 변경 없음 (diff는 전부 enum 1값 + description). `UPVOTE_ACCESSIBILITY` 는 v1 유저용으로 유지된다.

## 검증

- `spectral lint` — error 0
- prettier `format:check` 통과

## 머지 순서

이 PR → scc-server → scc-app / scc-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)