### PR TITLE
feat(admin): 폐업 추정 후보에 원본 레코드 상호명/주소 노출

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -3439,8 +3439,8 @@ components:
         originalName:
           type: string
           description:
-            폐업 추정의 근거가 된 원본 레코드의 상호명. PUBLIC_DATA면 공공데이터(행안부 인허가)
-            상호명이라 우리 place 이름과 다를 수 있다.
+            폐업 추정의 근거가 된 원본 레코드의 상호명. PUBLIC_DATA면
+            공공데이터(행안부 인허가) 상호명이라 우리 place 이름과 다를 수 있다.
         originalAddress:
           type: string
           description: 폐업 추정의 근거가 된 원본 레코드의 주소.

--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -3436,6 +3436,14 @@ components:
           description:
             매칭 신뢰도 (0.0~1.0). 낮은 신뢰도로 폐업 추정된 경우 등에 설정,
             없으면 null.
+        originalName:
+          type: string
+          description:
+            폐업 추정의 근거가 된 원본 레코드의 상호명. PUBLIC_DATA면 공공데이터(행안부 인허가)
+            상호명이라 우리 place 이름과 다를 수 있다.
+        originalAddress:
+          type: string
+          description: 폐업 추정의 근거가 된 원본 레코드의 주소.
       required:
         - id
         - placeId


### PR DESCRIPTION
## 배경

어드민 폐업 추정 목록(`/closedPlace`)은 매칭된 **우리 place**의 이름/주소만 렌더한다. 그래서 어떤 원본 레코드가 그 후보를 만들었는지 화면에서 알 수 없다.

실제 사례:
- 화면: `플러스카페 1호점(서울 종로구 종로1길 36), 2026-07-01 폐업 추정 · 출처: 공공데이터 · 신뢰도: 0.80`
- 실제 근거: 공공데이터 레코드 **`플러스까페 종로구청점`** (종로1길 36, 대림빌딩 지하1층)

이름이 달라서 "우리 DB에 없는 장소 아닌가?"라는 혼란이 발생했다.

## 변경

`AdminClosedPlaceCandidateDTO`에 `originalName`, `originalAddress` (optional) 추가. `closed_place_candidate.original_name/original_address`에 이미 저장돼 있는 값이라 서버는 매핑만 하면 된다.

## 후속

- scc-server: DTO 매핑
- scc-admin: place 이름과 다를 때만 `· 원본: …` 한 줄 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)