### PR TITLE
feat(admin): 폐업 추정 후보 목록에 검수 큐 필터 추가

### DIFF
--- a/admin-api-spec.yaml
+++ b/admin-api-spec.yaml
@@ -867,7 +867,19 @@ paths:
       summary: 폐업이 추정되는 장소의 리스트를 조회한다.
       parameters:
         - in: query
+          name: filter
+          description:
+            조회 대상 필터. 생략하면 NEEDS_ACTION. 하위 호환을 위해
+            isAccessibilityRegistered도 계속 지원하지만, 신규 클라이언트는 이
+            파라미터를 쓴다.
+          schema:
+            $ref: '#/components/schemas/AdminClosedPlaceCandidateFilterDTO'
+          required: false
+        - in: query
           name: isAccessibilityRegistered
+          description:
+            deprecated. filter=ACCESSIBILITY_REGISTERED와 동일. filter가 있으면
+            무시된다.
           schema:
             type: boolean
           required: false
@@ -3448,6 +3460,18 @@ components:
         - id
         - placeId
         - checkSource
+
+    AdminClosedPlaceCandidateFilterDTO:
+      type: string
+      description: |
+        폐업 추정 후보 목록 필터
+        - NEEDS_REVIEW: 교차검증에서 자동 판정이 안 돼 사람 판단이 필요한 것만 (검수 큐). 검수 판정 시각 최신순.
+        - NEEDS_ACTION: 아직 폐업 확정/무시 처리되지 않은 전체 후보
+        - ACCESSIBILITY_REGISTERED: NEEDS_ACTION 중 접근성 정보가 등록된 장소
+      enum:
+        - NEEDS_REVIEW
+        - NEEDS_ACTION
+        - ACCESSIBILITY_REGISTERED
 
     AdminClosureCheckSourceDTO:
       type: string


### PR DESCRIPTION
## 문제

어드민 폐업 추정 목록(`/closedPlace`)에서 **슬랙이 "사람 검수 필요"라고 알린 장소를 찾을 수 없다.**

실측(prod):

| | |
|---|---|
| 목록 총 row | **62,111** |
| 그중 이미 폐업 확정(`accepted_at` 있음)된 것 | **37,758 (61%)** — 필터에서 안 걸러짐 |
| 실제 검수가 필요한 것 | **65** |
| 그 65건의 목록 내 순위 | **2,189 ~ 18,160위** (중앙값 13,336) |
| 어드민 페이지 크기 | 10 → **"더 불러오기" 약 1,334번** |

정렬 기준이 `created_at DESC`, 즉 **후보 row가 처음 만들어진 시각(공공데이터 import 시각)** 이라서, "언제 사람 판단이 필요하다고 판정됐는지"(`cross_validated_at`)와 아무 상관이 없다.

## 변경

`AdminClosedPlaceCandidateFilterDTO` 추가:

- **`NEEDS_REVIEW`** — 교차검증에서 자동 판정이 안 된 검수 큐. **검수 판정 시각 최신순**
- **`NEEDS_ACTION`** — 아직 폐업 확정/무시되지 않은 전체 후보 (기본값)
- **`ACCESSIBILITY_REGISTERED`** — 그중 접근성 정보가 등록된 장소

`isAccessibilityRegistered`는 하위 호환용으로 남긴다(`filter`가 오면 무시).

## 후속

- scc-server: 필터 분기 + `accepted_at IS NULL` 누락 수정
- scc-admin: 검수 필요 탭을 기본으로, 페이지 크기 10 → 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)