### PR TITLE
feat: UpvoteTargetTypeDto 에 ARTICLE 추가

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -6513,8 +6513,9 @@ components:
           type: string
           description:
             조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다. 또한 이
-            URL 에서 좋아요 target (BBUCLE_ROAD path id 또는 ARTICLE slug) 도 추론한다.
-            정적 아티클 페이지에서 보낼 때는 canonical URL (https://web.staircrusher.club/articles/<slug>) 을 쓴다.
+            URL 에서 좋아요 target (BBUCLE_ROAD path id 또는 ARTICLE slug) 도
+            추론한다. 정적 아티클 페이지에서 보낼 때는 canonical URL
+            (https://web.staircrusher.club/articles/<slug>) 을 쓴다.
       required:
         - url
 

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -2047,7 +2047,8 @@ paths:
       description: |
         웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 요약을 통합 응답한다.
         - URL 기준으로 SccContent id + 현재 유저의 저장 여부.
-        - 서버가 URL pattern 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다.
+        - 서버가 URL pattern 에서 좋아요 target 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다.
+          (BBUCLE_ROAD: con.staircrusher.club / staircrusherclub.notion.site 의 path id, ARTICLE: web.staircrusher.club/articles/ 이하 경로)
         - 좋아요 개념이 적용되지 않는 URL 이면 upvoteSummary 는 null.
         - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다.
       operationId: getSccContentDetails
@@ -4989,6 +4990,7 @@ components:
         - PLACE_REVIEW
         - TOILET_REVIEW
         - BBUCLE_ROAD
+        - ARTICLE
 
     PlaceUpvoteInfoDto:
       type: object
@@ -6511,7 +6513,8 @@ components:
           type: string
           description:
             조회할 컨텐츠의 URL. 서버에서 정규화 후 SccContent를 찾는다. 또한 이
-            URL 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 도 추론한다.
+            URL 에서 좋아요 target (BBUCLE_ROAD path id 또는 ARTICLE slug) 도 추론한다.
+            정적 아티클 페이지에서 보낼 때는 canonical URL (https://web.staircrusher.club/articles/<slug>) 을 쓴다.
       required:
         - url
 


### PR DESCRIPTION
## 배경

`web.staircrusher.club/articles/<slug>` 정적 아티클 페이지 하단에 고정 CTA 바가 붙는다 (Figma 72:1445). 그 바의 하트(좋아요) 버튼이 서버 집계를 쓰려면 아티클용 upvote target 이 필요하다.

아티클은 **서버에 엔티티가 없는 콘텐츠**라 `BBUCLE_ROAD` 와 완전히 같은 경로를 탄다 (등록자 없음, 대상 존재 검증 없음).

## 변경

- `UpvoteTargetTypeDto` enum 에 `ARTICLE` 추가
- `getSccContentDetails` / `GetSccContentDetailsRequestDto` 의 URL→target 추론 설명에 두 타입을 모두 명시 (기존엔 BBUCLE_ROAD 만 언급)

## 다운스트림

- scc-server: enum 분기 5곳 + `UpvoteTargetResolver` 아티클 패턴 + `accessibility_id` 폭 확대 마이그레이션
- scc-app: 정적 페이지는 vanilla fetch 로 `targetType:'ARTICLE'` 문자열을 보내므로 generated 타입 무의존
- scc-admin: `UpvoteTargetType` 사용처 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)