### PR TITLE
feat: 대체 검색어 제안 API (/getAlternativeSearchSuggestion)

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1531,6 +1531,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchPlacesResponseDto'
 
+  /getAlternativeSearchSuggestion:
+    post:
+      summary: 포커스된 장소를 기준으로 대체 검색어를 제안할지 판단한다.
+      description: |
+        검색 결과에 접근레벨 2 이하인 장소가 하나도 없을 때(부정경험 상태) 클라이언트가 지도 카드
+        포커스가 확정될 때마다 호출한다. 해당 장소의 vendor 세부 카테고리(예: 한식)를 대체 검색어
+        후보로 뽑아 실제 재검색을 시뮬레이션하고, 접근레벨 2 이하 결과가 3개를 초과할 때만 제안을
+        내려준다. 제안할 것이 없으면 suggestion이 null이다. 비인증 유저도 조회 가능하다.
+      operationId: getAlternativeSearchSuggestion
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetAlternativeSearchSuggestionRequestDto'
+      responses:
+        '200':
+          description: 대체 검색 제안. 제안할 것이 없으면 suggestion이 null이다.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAlternativeSearchSuggestionResponseDto'
+
   /searchPlacesByNaturalLanguage:
     post:
       summary: 자연어로 장소를 검색한다.
@@ -4618,6 +4641,44 @@ components:
       enum:
         - PLACE
         - ACCESSIBLE_TOILET
+
+    GetAlternativeSearchSuggestionRequestDto:
+      type: object
+      properties:
+        placeId:
+          type: string
+          description: 지도 카드에서 현재 포커스된 장소의 ID
+        currentSearchText:
+          type: string
+          description:
+            현재 화면의 검색어. 대체 검색어가 이 값과 같으면 같은 말을 반복하게
+            되므로 제안하지 않는다.
+      required:
+        - placeId
+        - currentSearchText
+
+    GetAlternativeSearchSuggestionResponseDto:
+      type: object
+      properties:
+        suggestion:
+          $ref: '#/components/schemas/AlternativeSearchSuggestionDto'
+          description: 제안할 대체 검색이 없으면 null.
+
+    AlternativeSearchSuggestionDto:
+      type: object
+      properties:
+        searchText:
+          type: string
+          description:
+            대체 검색어. 버튼 라벨은 "주위 다른 {searchText} 확인하기".
+        circleRegion:
+          $ref: '#/components/schemas/CircleSearchRegionDto'
+          description:
+            서버가 제안 여부 판단에 사용한 원형 영역. 재검색 시 이 값을 그대로
+            /searchPlaces 의 circleRegion 으로 보내야 제안된 결과가 보장된다.
+      required:
+        - searchText
+        - circleRegion
 
     SearchUnconqueredPlacesNearbyRequestDto:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4661,11 +4661,11 @@ components:
       type: object
       properties:
         suggestion:
-          # OpenAPI 3.0 에서는 $ref 형제로 nullable 을 쓸 수 없어 allOf 로 감싼다.
-          allOf:
-            - $ref: '#/components/schemas/AlternativeSearchSuggestionDto'
-          nullable: true
-          description: 제안할 대체 검색이 없으면 null.
+          # allOf + nullable 로 감싸면 typescript-axios(6.2.0)가 AlternativeSearchSuggestionDto
+          # 를 재사용하지 않고 인라인 타입을 복제한다(타입 드리프트). 필드를 optional 로 두는
+          # 편이 낫다 — 클라이언트는 `?? null` 로 omission/null 을 함께 받는다.
+          $ref: '#/components/schemas/AlternativeSearchSuggestionDto'
+          description: 제안할 대체 검색이 없으면 null 또는 생략.
 
     AlternativeSearchSuggestionDto:
       type: object

--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -4661,7 +4661,10 @@ components:
       type: object
       properties:
         suggestion:
-          $ref: '#/components/schemas/AlternativeSearchSuggestionDto'
+          # OpenAPI 3.0 에서는 $ref 형제로 nullable 을 쓸 수 없어 allOf 로 감싼다.
+          allOf:
+            - $ref: '#/components/schemas/AlternativeSearchSuggestionDto'
+          nullable: true
           description: 제안할 대체 검색이 없으면 null.
 
     AlternativeSearchSuggestionDto:


### PR DESCRIPTION
## 배경

`SearchScreen`에서 "대한냉면 정자"처럼 **장소명**을 검색했는데 그 장소에 접근성 정보가 없으면, 사용자는 아무것도 얻지 못하고 탐색 플로우가 끊긴다(부정경험).

포커스된 카드 위에 `주위 다른 {한식} 확인하기` CTA를 띄워 탐색을 이어가게 하기 위한 API를 추가한다.

Spec: `specs/alternative-search-suggestion/spec.md` (scc-workspace)
Figma: [부정경험 개선 `214:147`](https://www.figma.com/design/GzoU4xIgT3tvid8wd4VPA0/%EB%B6%80%EC%A0%95%EA%B2%BD%ED%97%98-%EA%B0%9C%EC%84%A0?node-id=214-147)

## 설계 핵심

**서버가 제안하기 전에 그 검색을 실제로 해본다.** 부정경험을 완화하려는 기능이 다시 부정경험(눌렀는데 결과가 없음)을 만들면 안 되므로, 대체 검색어로 시뮬레이션 검색을 돌려 접근레벨 2 이하 결과가 3개를 초과할 때만 제안한다.

그래서 응답에 **서버가 시뮬레이션에 쓴 `circleRegion`을 그대로 실어 보낸다.** 클라이언트가 이 영역으로 재검색하면 판단 근거와 실제 검색이 어긋날 수 없다.

## 변경

| 스키마 | 변경 |
|---|---|
| `GetAlternativeSearchSuggestionRequestDto` | 신규 — `placeId`, `currentSearchText` |
| `GetAlternativeSearchSuggestionResponseDto` | 신규 — `suggestion` (없으면 null) |
| `AlternativeSearchSuggestionDto` | 신규 — `searchText`, `circleRegion` |
| `CircleSearchRegionDto` | 재사용 (변경 없음) |

`currentSearchText`를 받는 이유: 대체 검색어가 현재 검색어와 같으면("한식" 검색 중에 "주위 다른 한식 확인하기") 같은 말의 반복이라 제안하지 않는다.

## 검증

- `spectral lint` — No results with a severity of 'error' found
- `prettier --check` 통과

## 후속 PR

- scc-server: 구현
- scc-app: CTA + 재검색 플로우

🤖 Generated with [Claude Code](https://claude.com/claude-code)